### PR TITLE
feat : 탈퇴하기, 신고하기 기능 추가

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/member/controller/DeleteMemberController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/controller/DeleteMemberController.java
@@ -1,0 +1,59 @@
+package sequence.sequence_member.member.controller;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import sequence.sequence_member.global.exception.CanNotFindResourceException;
+import sequence.sequence_member.global.response.ApiResponseData;
+import sequence.sequence_member.member.dto.DeleteInputDTO;
+import sequence.sequence_member.member.entity.MemberEntity;
+import sequence.sequence_member.member.service.DeleteService;
+import sequence.sequence_member.member.service.MemberService;
+
+
+@RestController
+@RequiredArgsConstructor
+public class DeleteMemberController {
+
+    private final MemberService memberService;
+    private final DeleteService deleteService;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+
+    // 사용자 탈퇴 API
+    @DeleteMapping("/api/user/delete")
+    public ResponseEntity<ApiResponseData<String>> deleteProcess(@RequestBody DeleteInputDTO deleteInputDTO, HttpServletRequest request) {
+
+        //비밀번호 비교
+        if (!deleteInputDTO.getPassword().equals(deleteInputDTO.getConfirm_password())) {
+            throw new CanNotFindResourceException("동일한 비밀번호를 입력해주세요");
+        }
+
+        MemberEntity member = memberService.GetUser(deleteInputDTO.getUsername());
+
+        //입력 비밀번호를 db와 비교
+        if (!bCryptPasswordEncoder.matches(deleteInputDTO.getPassword(), member.getPassword())) {
+            throw new CanNotFindResourceException("비밀번호가 일치하지 않습니다.");
+        }
+
+        //리프레시 토큰 제거
+        //멤버 정보 제거
+        //삭제한 멤버 받아오기
+        //삭제한 user 정보 deleteMember 테이블에 저장
+        deleteService.deleteRefreshAndMember(request);
+
+        //성공 응답 반환
+        return ResponseEntity.ok().body(ApiResponseData.success(null, "회원탈퇴 성공적으로 완료되었습니다."));
+    }
+
+
+
+}
+

--- a/sequence_member/src/main/java/sequence/sequence_member/member/dto/DeleteInputDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/dto/DeleteInputDTO.java
@@ -1,0 +1,13 @@
+package sequence.sequence_member.member.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DeleteInputDTO {
+    private String username;
+    private String password;
+    private String confirm_password;
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/member/entity/DeleteEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/entity/DeleteEntity.java
@@ -1,0 +1,28 @@
+package sequence.sequence_member.member.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import sequence.sequence_member.global.utils.BaseTimeEntity;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class DeleteEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String email;
+
+    public DeleteEntity(String username, String email) {
+        this.username=username;
+        this.email=email;
+    }
+}
+

--- a/sequence_member/src/main/java/sequence/sequence_member/member/entity/EducationEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/entity/EducationEntity.java
@@ -24,7 +24,7 @@ public class EducationEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long    id ;
 
-    @OneToOne(mappedBy = "education")
+    @OneToOne
     @JoinColumn
     private MemberEntity member;
 

--- a/sequence_member/src/main/java/sequence/sequence_member/member/entity/MemberEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/entity/MemberEntity.java
@@ -74,7 +74,7 @@ public class MemberEntity extends BaseTimeEntity {
     @OneToMany(fetch = FetchType.LAZY,mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ExperienceEntity> experiences=new ArrayList<>();
 
-    @OneToOne(fetch = FetchType.LAZY,cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private EducationEntity education;
 
     public enum Gender{

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/AwardRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/AwardRepository.java
@@ -1,7 +1,16 @@
 package sequence.sequence_member.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import sequence.sequence_member.member.entity.AwardEntity;
 
+
+@Repository
 public interface AwardRepository extends JpaRepository<AwardEntity,Long> {
+    @Transactional
+    @Modifying
+    void deleteByMemberId(Long Id);
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/CareerRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/CareerRepository.java
@@ -1,7 +1,12 @@
 package sequence.sequence_member.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 import sequence.sequence_member.member.entity.CareerEntity;
 
 public interface CareerRepository extends JpaRepository<CareerEntity, Long> {
+    @Transactional
+    @Modifying
+    void deleteByMemberId(Long Id);
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/DeleteRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/DeleteRepository.java
@@ -1,0 +1,8 @@
+package sequence.sequence_member.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sequence.sequence_member.member.entity.DeleteEntity;
+
+public interface DeleteRepository extends JpaRepository<DeleteEntity, Long> {
+
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/EducationRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/EducationRepository.java
@@ -1,7 +1,12 @@
 package sequence.sequence_member.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 import sequence.sequence_member.member.entity.EducationEntity;
 
 public interface EducationRepository extends JpaRepository<EducationEntity, Long> {
+    @Transactional
+    @Modifying
+    void deleteByMemberId(Long Id);
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/ExperienceRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/ExperienceRepository.java
@@ -1,7 +1,12 @@
 package sequence.sequence_member.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 import sequence.sequence_member.member.entity.ExperienceEntity;
 
 public interface ExperienceRepository extends JpaRepository<ExperienceEntity, Long> {
+    @Transactional
+    @Modifying
+    void deleteByMemberId(Long Id);
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/MemberRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/MemberRepository.java
@@ -1,16 +1,28 @@
 package sequence.sequence_member.member.repository;
 
+import java.lang.reflect.Member;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import sequence.sequence_member.member.entity.MemberEntity;
 
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
+@Repository
 public interface MemberRepository extends JpaRepository<MemberEntity,Long> {
     Optional<MemberEntity> findByUsername(String username);
+    Optional<MemberEntity> findByNickname(String nickname);
+    boolean existsByNickname(String nickname);
+
+    @Transactional
+    @Modifying
+    void deleteByUsername(@Param("username") String username);
 
     List<MemberEntity> findByNicknameIn(List<String> nickanmeList);
 

--- a/sequence_member/src/main/java/sequence/sequence_member/member/service/DeleteService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/service/DeleteService.java
@@ -1,0 +1,92 @@
+package sequence.sequence_member.member.service;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sequence.sequence_member.global.exception.CanNotFindResourceException;
+import sequence.sequence_member.member.entity.DeleteEntity;
+import sequence.sequence_member.member.entity.MemberEntity;
+import sequence.sequence_member.member.jwt.JWTUtil;
+import sequence.sequence_member.member.repository.*;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteService {
+
+    private final DeleteRepository deletedRepository;
+    private final MemberRepository memberRepository;
+
+    private final AwardRepository awardRepository;
+    private final CareerRepository careerRepository;
+    private final EducationRepository educationRepository;
+    private final ExperienceRepository experienceRepository;
+
+    private final RefreshRepository refreshRepository;
+    private final JWTUtil jwtUtil;
+
+
+    @Transactional
+    public void deleteRefreshAndMember(HttpServletRequest request){
+        //refresh 토큰 가져오기
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for(Cookie cookie : cookies){
+            if(cookie.getName().equals("refresh")){
+                refresh = cookie.getValue();
+            }
+        }
+
+        //토큰 존재여부 확인
+        if (refresh == null) {
+            throw new CanNotFindResourceException("토큰이 존재하지 않습니다.");
+        }
+
+        //refresh token 만료되었는지 확인
+        try{
+            jwtUtil.isExpired(refresh);
+        }catch (ExpiredJwtException e){
+            //만료 되었으면 다시 로그인을 진행하여, 회원탈퇴를 진행
+            throw new CanNotFindResourceException("refresh 토큰이 만료되었습니다.");
+        }
+
+        //토큰이 refresh 인지 확인
+        String category = jwtUtil.getCategory(refresh);
+        if(!category.equals("refresh")){
+            //쿠기값이 유효하지 않습니다. 다시 로그인 해주세요
+            throw new CanNotFindResourceException("쿠기값이 유효하지 않습니다. 다시 로그인 해주세요");
+        }
+
+        //DB에 refresh 토큰이 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if(!isExist){
+            throw new CanNotFindResourceException("존재하지 않는 refresh 토큰 입니다.");
+        }
+
+        //refresh db에서 토큰 제거
+        refreshRepository.deleteByRefresh(refresh);
+
+        String username = jwtUtil.getUsername(refresh);
+        MemberEntity deleteMember = memberRepository.findByUsername(username).get();
+
+        awardRepository.deleteByMemberId(deleteMember.getId());
+        careerRepository.deleteByMemberId(deleteMember.getId());
+        experienceRepository.deleteByMemberId(deleteMember.getId());
+        educationRepository.deleteByMemberId(deleteMember.getId());
+
+        memberRepository.deleteByUsername(username);
+
+        saveDeletedUser(deleteMember.getUsername(), deleteMember.getEmail());
+    }
+
+    @Transactional
+    public void saveDeletedUser(String username, String email) {
+        DeleteEntity deletedUser = new DeleteEntity(username, email);
+        deletedRepository.save(deletedUser);
+    }
+
+
+}
+

--- a/sequence_member/src/main/java/sequence/sequence_member/member/service/MemberService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/service/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
     private final ExperienceRepository experienceRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    public void  save(MemberDTO memberDTO){
+    public void save(MemberDTO memberDTO){
 
         //memberDTO의 비밀번호 값을 암호화하여 memberDTO에 저장하고 memberEntity로 변환하여 저장
         //엔티티 클래스는 데이터베이스 구조를 반영해야 하며, 비즈니스 로직(회원가입, 로그인, 비밀번호 암호화)과 분리되어야 한다.
@@ -72,6 +72,20 @@ public class MemberService {
             throw new IllegalArgumentException("Username cannot be null or empty.");
         }
         return memberRepository.findByUsername(username).isPresent();
+    }
+
+    public boolean checkNickname(String nickname){
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new IllegalArgumentException("Nickname cannot be null or empty.");
+        }
+        return memberRepository.findByNickname(nickname).isPresent();
+    }
+
+    public MemberEntity GetUser(String username){
+        if(username == null || username.trim().isEmpty()){
+            throw new IllegalArgumentException("아이디를 입력해주세요.");
+        }
+        return memberRepository.findByUsername(username).get();
     }
 
 

--- a/sequence_member/src/main/java/sequence/sequence_member/report/controller/ReportController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/controller/ReportController.java
@@ -1,0 +1,39 @@
+package sequence.sequence_member.report.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sequence.sequence_member.global.response.ApiResponseData;
+import sequence.sequence_member.global.response.Code;
+import sequence.sequence_member.member.service.MemberService;
+import sequence.sequence_member.report.dto.ReportRequestDTO;
+import sequence.sequence_member.report.dto.ReportResponseDTO;
+import sequence.sequence_member.report.service.ReportService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/report")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+    private final MemberService memberService;
+
+    //신고하기
+    @PostMapping("/submit")
+    public ResponseEntity<ApiResponseData<String>> submitReport(@RequestBody ReportRequestDTO reportRequestDTO) {
+        //신고내역 저장
+        reportService.submitReport(reportRequestDTO);
+
+        //신고완료
+        return ResponseEntity.ok().body(ApiResponseData.success(null,"신고가 완료되었습니다."));
+    }
+
+    //신고내역 조회
+    @GetMapping("/{nickname}")
+    public ResponseEntity<ApiResponseData<List<ReportResponseDTO>>> getReport(@PathVariable("nickname") String nickname) {
+        return ResponseEntity.ok().body(ApiResponseData.of(Code.SUCCESS.getCode(), "신고내역 조회가 성공했습니다.",reportService.searchReport(nickname)));
+    }
+
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportRequestDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportRequestDTO.java
@@ -1,0 +1,19 @@
+package sequence.sequence_member.report.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+public class ReportRequestDTO {
+
+    private String nickname;
+    private String reportType;
+    private String reporter;
+
+    @NotBlank(message = "아이디는 필수 입력 값입니다.")
+    @Size(min= 4, max= 10, message = "아이디는 최소 4자 이상 최대 10자 이하입니다.")
+    private String reportContent;
+
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportResponseDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportResponseDTO.java
@@ -1,0 +1,13 @@
+package sequence.sequence_member.report.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Builder
+public class ReportResponseDTO {
+    private String reportType;
+    private String reportContent;
+    private String reporter;
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/report/entity/ReportEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/entity/ReportEntity.java
@@ -1,0 +1,28 @@
+package sequence.sequence_member.report.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import sequence.sequence_member.global.utils.BaseTimeEntity;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "report")
+public class ReportEntity extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String nickname;
+    private String reporter;
+
+    @Column(nullable = false)
+    private String reportType;
+
+    @Column(columnDefinition = "TEXT", length = 500)
+    private String reportContent;
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/report/repository/ReportRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/repository/ReportRepository.java
@@ -1,0 +1,11 @@
+package sequence.sequence_member.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sequence.sequence_member.report.entity.ReportEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
+    List<ReportEntity> findByNickname(String nickname);
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/report/service/ReportService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/service/ReportService.java
@@ -1,0 +1,55 @@
+package sequence.sequence_member.report.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sequence.sequence_member.global.exception.CanNotFindResourceException;
+import sequence.sequence_member.member.repository.MemberRepository;
+import sequence.sequence_member.report.dto.ReportRequestDTO;
+import sequence.sequence_member.report.dto.ReportResponseDTO;
+import sequence.sequence_member.report.entity.ReportEntity;
+import sequence.sequence_member.report.repository.ReportRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final ReportRepository reportRepository;
+    private final MemberRepository memberRepository;
+
+    //신고내용을 db에 저장
+    public void submitReport(ReportRequestDTO reportRequestDTO){
+        boolean exist = memberRepository.existsByNickname(reportRequestDTO.getNickname());
+        if(!exist){
+            throw new CanNotFindResourceException("해당 유저가 존재하지 않습니다.");
+        }
+
+        ReportEntity reportEntity = ReportEntity.builder()
+                        .nickname(reportRequestDTO.getNickname())
+                        .reporter(reportRequestDTO.getReporter())
+                        .reportType(reportRequestDTO.getReportType())
+                        .reportContent(reportRequestDTO.getReportContent())
+                        .build();
+
+        reportRepository.save(reportEntity);
+    }
+
+    //신고 내역 조회
+    public List<ReportResponseDTO> searchReport(String nickname){
+        List<ReportEntity> reportEntities = reportRepository.findByNickname(nickname);
+        List<ReportResponseDTO> reportResponseDTOS = new ArrayList<>();
+
+        for(ReportEntity reportEntity : reportEntities){
+            reportResponseDTOS.add(ReportResponseDTO.builder()
+                    .reportType(reportEntity.getReportType())
+                    .reportContent(reportEntity.getReportContent())
+                    .reporter(reportEntity.getReporter())
+                    .build());
+        }
+
+        return reportResponseDTOS;
+    }
+
+}


### PR DESCRIPTION
[목적]
- 유저 탈퇴하기 기능 추가
- 유저 신고하기 기능 추가

[목표]
- 유저의 모든 정보를 Cascade로 삭제하고, refresh 토큰 정보를 삭제
- 탈퇴된 멤버는 탈퇴 멤버 테이블에 저장하여 관리
- 신고당한 유저는, 유저 정보와 신고내역을 테이블에 저장하여 관리

[달성도] : 구현 완료

[기타]
- 모든 예외처리 사항을 찾기 위해서 지속적인 테스트 필요