### PR TITLE
feat : 마이페이지 조회 및 수정 기능 구현, 회원가입 로직 개선

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/member/entity/AwardEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/entity/AwardEntity.java
@@ -1,8 +1,8 @@
 package sequence.sequence_member.member.entity;
 
 import jakarta.persistence.*;
-import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import sequence.sequence_member.global.enums.enums.AwardType;
 import sequence.sequence_member.global.utils.BaseTimeEntity;
@@ -13,11 +13,11 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-
 @Entity
 @Getter
 @Setter
 @Table(name = "award")
+@NoArgsConstructor
 public class AwardEntity extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,6 +41,18 @@ public class AwardEntity extends BaseTimeEntity {
     @Temporal(TemporalType.DATE)
     private Date awardDuration;
 
+    public AwardEntity(
+            AwardType awardType, String organizer,
+            String awardName, Date awardDuration,
+            MemberEntity member
+    ) {
+        this.awardType = awardType;
+        this.organizer = organizer;
+        this.awardName = awardName;
+        this.awardDuration = awardDuration;
+        this.member = member;
+    }
+
     public static List<AwardEntity> toAwardEntity(MemberDTO memberDTO, MemberEntity memberEntity) {
         List<AwardEntity> awardEntities = new ArrayList<>();
 
@@ -55,7 +67,5 @@ public class AwardEntity extends BaseTimeEntity {
             awardEntities.add(awardEntity);
         }
         return awardEntities;
-
     }
-
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/entity/CareerEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/entity/CareerEntity.java
@@ -1,22 +1,21 @@
 package sequence.sequence_member.member.entity;
 
 import jakarta.persistence.*;
-import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import sequence.sequence_member.global.utils.BaseTimeEntity;
 import sequence.sequence_member.member.dto.MemberDTO;
-
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-
 @Entity
 @Getter
 @Setter
 @Table(name="career")
+@NoArgsConstructor
 public class CareerEntity extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,6 +35,15 @@ public class CareerEntity extends BaseTimeEntity {
     @Column(nullable = false)
     private String careerDescription;
 
+    public CareerEntity(
+            String companyName, Date careerDuration,
+            String careerDescription, MemberEntity member
+    ) {
+        this.companyName = companyName;
+        this.careerDuration = careerDuration;
+        this.careerDescription = careerDescription;
+        this.member = member;
+    }
 
     public static List<CareerEntity> toCareerEntity(MemberDTO memberDTO, MemberEntity memberEntity){
         List<CareerEntity> careerEntities = new ArrayList<>();
@@ -51,6 +59,5 @@ public class CareerEntity extends BaseTimeEntity {
             careerEntities.add(careerEntity);
         }
         return careerEntities;
-
     }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/entity/EducationEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/entity/EducationEntity.java
@@ -1,11 +1,11 @@
 package sequence.sequence_member.member.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Size;
 import lombok.Data;
 
-import org.intellij.lang.annotations.Pattern;
+import lombok.NoArgsConstructor;
 import sequence.sequence_member.global.enums.enums.Degree;
+import sequence.sequence_member.global.enums.enums.ProjectRole;
 import sequence.sequence_member.global.enums.enums.Skill;
 import sequence.sequence_member.global.utils.BaseTimeEntity;
 import sequence.sequence_member.member.converter.DesiredJobConverter;
@@ -19,6 +19,7 @@ import java.util.List;
 @Entity
 @Data
 @Table(name="education")
+@NoArgsConstructor
 public class EducationEntity extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -61,6 +62,24 @@ public class EducationEntity extends BaseTimeEntity {
     @Column(name = "desired_job")
     private List<sequence.sequence_member.global.enums.enums.ProjectRole> desiredJob;
 
+    public EducationEntity(
+            String schoolName, String major,
+            String grade, Date entranceDate,
+            Date graduationDate, Degree degree,
+            List<Skill> skillCategory, List<ProjectRole> desiredJob,
+            MemberEntity member
+    ) {
+       this.schoolName = schoolName;
+       this.major = major;
+       this.grade = grade;
+       this.entranceDate = entranceDate;
+       this.graduationDate = graduationDate;
+       this.degree = degree;
+       this.skillCategory = skillCategory;
+       this.desiredJob = desiredJob;
+       this.member = member;
+    }
+
     public static EducationEntity toEducationEntity(MemberDTO memberDTO, MemberEntity memberEntity){
         EducationEntity educationEntity = new EducationEntity();
 
@@ -75,5 +94,21 @@ public class EducationEntity extends BaseTimeEntity {
         educationEntity.setMember(memberEntity);
 
         return educationEntity;
+    }
+
+    public void updateEducation(
+            String schoolName, String major,
+            String grade, Date entranceDate,
+            Date graduationDate, Degree degree,
+            List<Skill> skillCategory, List<ProjectRole> desiredJob
+    ) {
+        this.schoolName = schoolName;
+        this.major = major;
+        this.grade = grade;
+        this.entranceDate = entranceDate;
+        this.graduationDate = graduationDate;
+        this.degree = degree;
+        this.skillCategory = skillCategory;
+        this.desiredJob = desiredJob;
     }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/entity/ExperienceEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/entity/ExperienceEntity.java
@@ -1,23 +1,22 @@
 package sequence.sequence_member.member.entity;
 
 import jakarta.persistence.*;
-import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import sequence.sequence_member.global.enums.enums.ExperienceType;
 import sequence.sequence_member.global.utils.BaseTimeEntity;
 import sequence.sequence_member.member.dto.MemberDTO;
 
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
 
 @Getter
 @Setter
 @Entity
 @Table(name = "experience")
+@NoArgsConstructor
 public class ExperienceEntity extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,8 +37,20 @@ public class ExperienceEntity extends BaseTimeEntity {
     private String experienceDescription;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn
+    @JoinColumn(name = "member_id")
     private MemberEntity member;
+
+    public ExperienceEntity(
+            ExperienceType experienceType, String experienceName,
+            Date experienceDuration, String experienceDescription,
+            MemberEntity member
+    ) {
+        this.experienceType = experienceType;
+        this.experienceName = experienceName;
+        this.experienceDuration = experienceDuration;
+        this.experienceDescription = experienceDescription;
+        this.member = member;
+    }
 
     public static List<ExperienceEntity> toExperienceEntity(MemberDTO memberDTO, MemberEntity memberEntity){
         List<ExperienceEntity> experienceEntities = new ArrayList<>();
@@ -58,6 +69,5 @@ public class ExperienceEntity extends BaseTimeEntity {
         }
 
         return experienceEntities;
-
     }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/entity/MemberEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/entity/MemberEntity.java
@@ -1,7 +1,6 @@
 package sequence.sequence_member.member.entity;
 
 import jakarta.persistence.*;
-import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import sequence.sequence_member.global.utils.BaseTimeEntity;
@@ -58,7 +57,6 @@ public class MemberEntity extends BaseTimeEntity {
     @Column(name="profile_img")
     private String profileImg; // todo - 파일을 minio에 저장하고 url을 저장하는 방식으로 변경
 
-
     // AwardEntity와의 일대다 관계 설정
     @OneToMany(fetch = FetchType.LAZY,mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AwardEntity> awards=new ArrayList<>();
@@ -72,6 +70,7 @@ public class MemberEntity extends BaseTimeEntity {
     private List<ExperienceEntity> experiences=new ArrayList<>();
 
     @OneToOne(fetch = FetchType.LAZY,cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "education_id")
     private EducationEntity education;
 
     public enum Gender{

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/AwardRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/AwardRepository.java
@@ -2,6 +2,10 @@ package sequence.sequence_member.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import sequence.sequence_member.member.entity.AwardEntity;
+import sequence.sequence_member.member.entity.MemberEntity;
+
+import java.util.List;
 
 public interface AwardRepository extends JpaRepository<AwardEntity,Long> {
+    List<AwardEntity> findByMember(MemberEntity member);
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/CareerRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/CareerRepository.java
@@ -2,6 +2,10 @@ package sequence.sequence_member.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import sequence.sequence_member.member.entity.CareerEntity;
+import sequence.sequence_member.member.entity.MemberEntity;
+
+import java.util.List;
 
 public interface CareerRepository extends JpaRepository<CareerEntity, Long> {
+    List<CareerEntity> findByMember(MemberEntity member);
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/EducationRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/EducationRepository.java
@@ -2,6 +2,10 @@ package sequence.sequence_member.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import sequence.sequence_member.member.entity.EducationEntity;
+import sequence.sequence_member.member.entity.MemberEntity;
+
+import java.util.Optional;
 
 public interface EducationRepository extends JpaRepository<EducationEntity, Long> {
+    Optional<EducationEntity> findByMember(MemberEntity member);
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/ExperienceRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/ExperienceRepository.java
@@ -2,6 +2,10 @@ package sequence.sequence_member.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import sequence.sequence_member.member.entity.ExperienceEntity;
+import sequence.sequence_member.member.entity.MemberEntity;
+
+import java.util.List;
 
 public interface ExperienceRepository extends JpaRepository<ExperienceEntity, Long> {
+    List<ExperienceEntity> findByMember(MemberEntity member);
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/MemberRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/MemberRepository.java
@@ -14,6 +14,8 @@ public interface MemberRepository extends JpaRepository<MemberEntity,Long> {
 
     List<MemberEntity> findByNicknameIn(List<String> nickanmeList);
 
+    Optional<MemberEntity> findById(Long userId);
+
 //    List<String> findByNicknameContaining(String nickname, int limit);
 
     @Query("""

--- a/sequence_member/src/main/java/sequence/sequence_member/member/service/MemberService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package sequence.sequence_member.member.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,7 @@ public class MemberService {
     private final ExperienceRepository experienceRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
+    @Transactional
     public void  save(MemberDTO memberDTO){
 
         //memberDTO의 비밀번호 값을 암호화하여 memberDTO에 저장하고 memberEntity로 변환하여 저장
@@ -44,10 +46,15 @@ public class MemberService {
         List<CareerEntity> careerEntities  = CareerEntity.toCareerEntity(memberDTO, memberEntityCopy);
         EducationEntity educationEntity = EducationEntity.toEducationEntity(memberDTO, memberEntityCopy);
 
+        // 관계 설정
+        educationEntity.setMember(memberEntityCopy);
+        memberEntityCopy.setEducation(educationEntity);
+
         experienceRepository.saveAll(experienceEntities);
         careerRepository.saveAll(careerEntities);
         awardRepository.saveAll(awardEntities);
         educationRepository.save(educationEntity);
+        memberRepository.save(memberEntityCopy); // MemberEntity도 다시 저장하여 FK 설정
     }
 
     /* 회원가입 시, 유효성 체크 */
@@ -73,6 +80,4 @@ public class MemberService {
         }
         return memberRepository.findByUsername(username).isPresent();
     }
-
-
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/controller/MyPageController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/controller/MyPageController.java
@@ -1,0 +1,57 @@
+package sequence.sequence_member.mypage.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import sequence.sequence_member.global.response.ApiResponseData;
+import sequence.sequence_member.global.response.Code;
+import sequence.sequence_member.member.jwt.JWTUtil;
+import sequence.sequence_member.mypage.dto.MyPageDTO;
+import sequence.sequence_member.mypage.service.MyPageService;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class MyPageController {
+    private final MyPageService myPageService;
+    private final JWTUtil jwtUtil;
+
+    @GetMapping("/api/mypage")
+    public ResponseEntity<ApiResponseData> getMyPage(HttpServletRequest request) {
+
+        String username = jwtUtil.getUsername(request.getHeader("access"));
+
+        try {
+            MyPageDTO myPageDTO = myPageService.searchMyPage(username);
+            // 성공 응답 생성
+            return ResponseEntity.ok(ApiResponseData.success(myPageDTO, "사용자 정보를 성공적으로 가져왔습니다."));
+        } catch (Exception e) {
+            // 예외 발생 시 처리
+            ApiResponseData errorResponse = ApiResponseData.failure(
+                    Code.CAN_NOT_FIND_RESOURCE.getCode(),
+                    e.getMessage()
+            );
+            return ResponseEntity.status(Code.CAN_NOT_FIND_RESOURCE.getStatus()).body(errorResponse);
+        }
+    }
+
+    @PutMapping("/api/mypage")
+    public ResponseEntity<ApiResponseData<String>> updateMyPageInfo(@RequestBody MyPageDTO myPageDTO) {
+
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        try {
+            myPageService.updateMyPage(myPageDTO, username);
+            return ResponseEntity.ok(ApiResponseData.success("마이페이지 수정이 완료되었습니다."));
+        } catch (Exception e) {
+            return ResponseEntity.status(Code.CAN_NOT_FIND_RESOURCE.getStatus())
+                    .body(ApiResponseData.failure(Code.CAN_NOT_FIND_RESOURCE.getCode(), "예외가 발생했습니다: " + e.getMessage()));
+        }
+    }
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageDTO.java
@@ -1,0 +1,92 @@
+package sequence.sequence_member.mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import sequence.sequence_member.global.enums.enums.AwardType;
+import sequence.sequence_member.global.enums.enums.Degree;
+import sequence.sequence_member.global.enums.enums.ExperienceType;
+import sequence.sequence_member.global.enums.enums.ProjectRole;
+import sequence.sequence_member.global.enums.enums.Skill;
+import sequence.sequence_member.member.entity.MemberEntity.Gender;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+public class MyPageDTO {
+    @NotBlank(message = "아이디는 필수 입력 값입니다.")
+    @Size(min= 4, max= 10, message = "아이디는 최소 4자 이상 최대 10자 이하입니다.")
+    private String username;
+
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    private String name;
+
+    @NotNull(message = "생년월일은 필수 입력 값입니다.")
+    private Date birth;
+
+    @NotNull(message = "성별은 필수 입력 값입니다.")
+    private Gender gender;
+
+    @NotBlank(message = "주소지는 필수 입력 값입니다.")
+    private String address;
+
+    @NotBlank(message = "휴대폰 번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
+    private String phone;
+
+    private String introduction;
+    private String portfolio; // todo - minio에 저장할 수 있도록 추가해야 함
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    private String nickname;
+
+    @NotBlank(message = "학교명은 필수 입력 값입니다.")
+    private String schoolName;
+
+    @NotBlank(message = "전공은 필수 입력 값입니다.")
+    private String major;
+
+    @NotBlank(message = "학년은 필수 입력 값입니다.")
+    @Pattern(regexp = "^[1-6]학년$", message = "학년은 1학년부터 6학년까지 입력 가능합니다.")
+    private String grade;
+
+    private Date entranceDate;
+
+    private Date graduationDate;
+
+    @NotNull(message = "학위는 필수 입력 값입니다.")
+    private Degree degree;
+
+    private List<Skill> skillCategory;
+    private List<ProjectRole> desiredJob;
+
+    private List<AwardDTO> awards;
+    private List<CareerDTO> careers;
+    private List<ExperienceDTO> experiences;
+
+    @Data
+    public static class AwardDTO {
+        private AwardType awardType;
+        private String organizer;
+        private String awardName;
+        private Date awardDuration;
+    }
+
+    @Data
+    public static class CareerDTO {
+        private String companyName;
+        private Date careerDuration;
+        private String careerDescription;
+    }
+
+    @Data
+    public static class ExperienceDTO {
+        private ExperienceType experienceType;
+        private String experienceName;
+        private Date experienceDuration;
+        private String experienceDescription;
+    }
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageService.java
@@ -1,0 +1,189 @@
+package sequence.sequence_member.mypage.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import sequence.sequence_member.member.entity.AwardEntity;
+import sequence.sequence_member.member.entity.CareerEntity;
+import sequence.sequence_member.member.entity.EducationEntity;
+import sequence.sequence_member.member.entity.ExperienceEntity;
+import sequence.sequence_member.member.entity.MemberEntity;
+import sequence.sequence_member.member.repository.AwardRepository;
+import sequence.sequence_member.member.repository.CareerRepository;
+import sequence.sequence_member.member.repository.EducationRepository;
+import sequence.sequence_member.member.repository.ExperienceRepository;
+import sequence.sequence_member.member.repository.MemberRepository;
+import sequence.sequence_member.mypage.dto.MyPageDTO;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MyPageService {
+
+    private final MemberRepository memberRepository;
+    private final AwardRepository awardRepository;
+    private final CareerRepository careerRepository;
+    private final EducationRepository educationRepository;
+    private final ExperienceRepository experienceRepository;
+
+    // 마이페이지 조회
+    public MyPageDTO searchMyPage(String username) {
+        // 1. 회원 정보 가져오기
+        MemberEntity member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
+
+        log.info("member: {}", member.getEducation());
+
+        return convertToDTO(member);
+    }
+
+    private MyPageDTO convertToDTO(MemberEntity member) {
+        MyPageDTO dto = new MyPageDTO();
+        dto.setUsername(member.getUsername());
+        dto.setName(member.getName());
+        dto.setBirth(member.getBirth());
+        dto.setGender(member.getGender());
+        dto.setAddress(member.getAddress());
+        dto.setPhone(member.getPhone());
+        dto.setIntroduction(member.getIntroduction());
+        dto.setPortfolio(member.getPortfolio());
+        dto.setNickname(member.getNickname());
+
+        dto.setAwards(member.getAwards().stream()
+                .map(award -> {
+                    MyPageDTO.AwardDTO awardDTO = new MyPageDTO.AwardDTO();
+                    awardDTO.setAwardType(award.getAwardType());
+                    awardDTO.setOrganizer(award.getOrganizer());
+                    awardDTO.setAwardName(award.getAwardName());
+                    awardDTO.setAwardDuration(award.getAwardDuration());
+                    return awardDTO;
+                })
+                .collect(Collectors.toList()));
+
+        dto.setCareers(member.getCareers().stream()
+                .map(career -> {
+                    MyPageDTO.CareerDTO careerDTO = new MyPageDTO.CareerDTO();
+                    careerDTO.setCompanyName(career.getCompanyName());
+                    careerDTO.setCareerDuration(career.getCareerDuration());
+                    careerDTO.setCareerDescription(career.getCareerDescription());
+                    return careerDTO;
+                })
+                .collect(Collectors.toList()));
+
+        dto.setExperiences(member.getExperiences().stream()
+                .map(experience -> {
+                    MyPageDTO.ExperienceDTO experienceDTO = new MyPageDTO.ExperienceDTO();
+                    experienceDTO.setExperienceType(experience.getExperienceType());
+                    experienceDTO.setExperienceName(experience.getExperienceName());
+                    experienceDTO.setExperienceDuration(experience.getExperienceDuration());
+                    experienceDTO.setExperienceDescription(experience.getExperienceDescription());
+                    return experienceDTO;
+                })
+                .collect(Collectors.toList()));
+
+        dto.setSchoolName(member.getEducation().getSchoolName());
+        dto.setMajor(member.getEducation().getMajor());
+        dto.setGrade(member.getEducation().getGrade());
+        dto.setEntranceDate(member.getEducation().getEntranceDate());
+        dto.setGraduationDate(member.getEducation().getGraduationDate());
+        dto.setDegree(member.getEducation().getDegree());
+        dto.setSkillCategory(member.getEducation().getSkillCategory());
+        dto.setDesiredJob(member.getEducation().getDesiredJob());
+
+        return dto;
+    }
+
+    /**
+     * 사용자 마이페이지 정보를 업데이트하는 메서드입니다.
+     *
+     * 현재는 기존 데이터를 삭제하고 새로 입력된 데이터를 저장하는 방식으로 구현되어 있습니다.
+     * 이 방식은 입력에 없는 데이터를 삭제하기 위해 선택되었습니다. 왜냐하면, 입력된 데이터와 기존 데이터를 비교하여
+     * 어떤 데이터를 삭제할지 결정하는 로직을 구현하기 어려운 상황이기 때문입니다.
+     * 이 방식은 데이터가 많을 경우 성능에 비효율적일 수 있으므로, 향후 효율적인 방식으로 개선이 필요합니다.
+     */
+    // 마이페이지 데이터 저장
+    @Transactional
+    public void updateMyPage(MyPageDTO myPageDTO, String username) {
+        // 1. 회원 정보 가져오기
+        MemberEntity member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
+
+        // 토큰과 body의 username이 같은지 확인
+        if(!Objects.equals(myPageDTO.getUsername(), username)) throw new IllegalArgumentException("아이디는 변경할 수 없습니다.");
+
+        // 기본 정보 업데이트 (변경 감지 사용)
+        // username은 변경하지 안음.
+        member.setName(myPageDTO.getName());
+        member.setBirth(myPageDTO.getBirth());
+        member.setGender(myPageDTO.getGender());
+        member.setAddress(myPageDTO.getAddress());
+        member.setPhone(myPageDTO.getPhone());
+        member.setIntroduction(myPageDTO.getIntroduction());
+        member.setPortfolio(myPageDTO.getPortfolio());
+        member.setNickname(myPageDTO.getNickname());
+
+        // 수상 내역 업데이트
+        List<AwardEntity> existingAwards = awardRepository.findByMember(member);
+        awardRepository.deleteAll(existingAwards);
+
+        for (MyPageDTO.AwardDTO dto : myPageDTO.getAwards()) {
+            AwardEntity newAward = new AwardEntity(dto.getAwardType(), dto.getOrganizer(), dto.getAwardName(), dto.getAwardDuration(), member);
+            awardRepository.save(newAward);
+        }
+
+        // 경력 업데이트
+        List<CareerEntity> existingCareers = careerRepository.findByMember(member);
+        careerRepository.deleteAll(existingCareers);
+
+        for (MyPageDTO.CareerDTO dto : myPageDTO.getCareers()) {
+            CareerEntity newCareer = new CareerEntity(dto.getCompanyName(), dto.getCareerDuration(), dto.getCareerDescription(), member);
+            careerRepository.save(newCareer);
+        }
+
+        // 경험 업데이트
+        List<ExperienceEntity> existingExperiences = experienceRepository.findByMember(member);
+        experienceRepository.deleteAll(existingExperiences);
+
+        for (MyPageDTO.ExperienceDTO dto : myPageDTO.getExperiences()) {
+            ExperienceEntity newExperience = new ExperienceEntity(dto.getExperienceType(), dto.getExperienceName(), dto.getExperienceDuration(), dto.getExperienceDescription(), member);
+            experienceRepository.save(newExperience);
+        }
+
+        // 학력 업데이트 (없으면 생성, 있으면 수정)
+        educationRepository.findByMember(member).ifPresentOrElse(
+                education -> {
+                    education.updateEducation(
+                            myPageDTO.getSchoolName(),
+                            myPageDTO.getMajor(),
+                            myPageDTO.getGrade(),
+                            myPageDTO.getEntranceDate(),
+                            myPageDTO.getGraduationDate(),
+                            myPageDTO.getDegree(),
+                            myPageDTO.getSkillCategory(),
+                            myPageDTO.getDesiredJob()
+                    );
+                },
+                () -> {
+                    EducationEntity newEducation = new EducationEntity(
+                            myPageDTO.getSchoolName(),
+                            myPageDTO.getMajor(),
+                            myPageDTO.getGrade(),
+                            myPageDTO.getEntranceDate(),
+                            myPageDTO.getGraduationDate(),
+                            myPageDTO.getDegree(),
+                            myPageDTO.getSkillCategory(),
+                            myPageDTO.getDesiredJob(),
+                            member
+                    );
+                    educationRepository.save(newEducation);
+                }
+        );
+    }
+}


### PR DESCRIPTION
[목적]
- 마이페이지 조회 기능 구현: 유저의 정보를 반환하는 API 추가
- 마이페이지 수정 기능 구현: 유저의 정보를 수정하는 API 추가
- 회원가입 로직 개선: 회원가입 시 테이블 간의 관계를 고려한 로직 추가

[목표]
- 마이페이지 조회 시, 해당 유저 정보를 반환
- 마이페이지 수정 시, 유저의 정보가 변경되도록 처리
- 회원가입 시, 테이블 간의 관계를 정확히 설정하여 데이터 일관성 유지

[달성도]
- 마이페이지 조회 및 수정 기능 구현 완료
- 회원가입 로직에서 테이블 관계 처리 완료

[기타]
- 마이페이지 수정 로직 개선이 필요할 수 있음
- 추후 예외처리 및 로직 검토 예정