### PR TITLE
feat: 아카이브 CRUD 기능 구현

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/archive/controller/ArchiveController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/controller/ArchiveController.java
@@ -1,9 +1,11 @@
 package sequence.sequence_member.archive.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import sequence.sequence_member.archive.dto.ArchiveOutputDTO;
 import sequence.sequence_member.archive.dto.ArchivePageResponseDTO;
 import sequence.sequence_member.archive.dto.ArchiveRegisterInputDTO;
 import sequence.sequence_member.archive.service.ArchiveService;
@@ -19,18 +21,10 @@ public class ArchiveController {
 
     private final ArchiveService archiveService;
 
-    /**
-     * 아카이브 등록 엔드포인트
-     * @param archiveRegisterInputDTO
-     * @return archiveOutputDTO
-     */
-
     @PostMapping
-    public ResponseEntity<Long> createArchive(@Validated @RequestBody ArchiveRegisterInputDTO archiveRegisterInputDTO) {
-        // 등록 서비스 호출
-        Long id = archiveService.createArchive(archiveRegisterInputDTO);
-        // 성공적으로 등록된 id 반환
-        return ResponseEntity.ok(id);
+    public ResponseEntity<ArchiveOutputDTO> createArchive(@Valid @RequestBody ArchiveRegisterInputDTO archiveRegisterInputDTO) {
+        ArchiveOutputDTO response = archiveService.createArchive(archiveRegisterInputDTO);
+        return ResponseEntity.ok(response);
     }
 
     // 전체 리스트 조회

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/controller/ArchiveController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/controller/ArchiveController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import sequence.sequence_member.archive.dto.ArchiveOutputDTO;
 import sequence.sequence_member.archive.dto.ArchivePageResponseDTO;
 import sequence.sequence_member.archive.dto.ArchiveRegisterInputDTO;
+import sequence.sequence_member.archive.dto.ArchiveUpdateDTO;
 import sequence.sequence_member.archive.service.ArchiveService;
 import sequence.sequence_member.global.enums.enums.Category;
 import sequence.sequence_member.global.enums.enums.SortType;
@@ -21,10 +22,32 @@ public class ArchiveController {
 
     private final ArchiveService archiveService;
 
+    // 아카이브 등록
     @PostMapping
-    public ResponseEntity<ArchiveOutputDTO> createArchive(@Valid @RequestBody ArchiveRegisterInputDTO archiveRegisterInputDTO) {
-        ArchiveOutputDTO response = archiveService.createArchive(archiveRegisterInputDTO);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<ApiResponseData<String>> createArchive(@Valid @RequestBody ArchiveRegisterInputDTO archiveRegisterInputDTO) {
+        archiveService.createArchive(archiveRegisterInputDTO);
+        return ResponseEntity.ok(ApiResponseData.success(null, "아카이브 등록 성공"));
+    }
+
+    // 아카이브 등록 후 결과 조회
+    @GetMapping("/{archiveId}")
+    public ResponseEntity<ApiResponseData<ArchiveOutputDTO>> getArchiveById(@PathVariable("archiveId") Long archiveId) {
+        return ResponseEntity.ok().body(ApiResponseData.of(Code.SUCCESS.getCode(), "아카이브 상세 조회 성공", archiveService.getArchiveById(archiveId)));
+    }
+
+    // 아카이브 수정
+    @PutMapping("/{archiveId}")
+    public ResponseEntity<ApiResponseData<String>> updateArchive(@PathVariable("archiveId") Long archiveId,
+                                                                 @Valid @RequestBody ArchiveUpdateDTO archiveUpdateDTO) {
+        archiveService.updateArchive(archiveId, archiveUpdateDTO);
+        return ResponseEntity.ok(ApiResponseData.success(null, "아카이브 수정 성공"));
+    }
+
+    // 아카이브 삭제
+    @DeleteMapping("/{archiveId}")
+    public ResponseEntity<ApiResponseData<String>> deleteArchiveById(@PathVariable("archiveId") Long archiveId) {
+        archiveService.deleteArchive(archiveId);
+        return ResponseEntity.ok(ApiResponseData.success(null, "아카이브 삭제 성공"));
     }
 
     // 전체 리스트 조회

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/controller/ArchiveController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/controller/ArchiveController.java
@@ -2,11 +2,10 @@ package sequence.sequence_member.archive.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 import sequence.sequence_member.archive.dto.ArchivePageResponseDTO;
+import sequence.sequence_member.archive.dto.ArchiveRegisterInputDTO;
 import sequence.sequence_member.archive.service.ArchiveService;
 import sequence.sequence_member.global.enums.enums.Category;
 import sequence.sequence_member.global.enums.enums.SortType;
@@ -19,6 +18,20 @@ import sequence.sequence_member.global.response.Code;
 public class ArchiveController {
 
     private final ArchiveService archiveService;
+
+    /**
+     * 아카이브 등록 엔드포인트
+     * @param archiveRegisterInputDTO
+     * @return archiveOutputDTO
+     */
+
+    @PostMapping
+    public ResponseEntity<Long> createArchive(@Validated @RequestBody ArchiveRegisterInputDTO archiveRegisterInputDTO) {
+        // 등록 서비스 호출
+        Long id = archiveService.createArchive(archiveRegisterInputDTO);
+        // 성공적으로 등록된 id 반환
+        return ResponseEntity.ok(id);
+    }
 
     // 전체 리스트 조회
     @GetMapping("/projects")

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveRegisterInputDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveRegisterInputDTO.java
@@ -1,0 +1,50 @@
+package sequence.sequence_member.archive.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.hibernate.validator.constraints.Length;
+import sequence.sequence_member.global.enums.enums.Category;
+import sequence.sequence_member.global.enums.enums.Period;
+import sequence.sequence_member.global.enums.enums.Status;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArchiveRegisterInputDTO {
+
+    @NotEmpty(message = "제목을 입력해주세요.")
+    @Length(min = 1, max = 40, message = "제목은 40자 이하로 입력해주세요.")
+    private String title;
+
+    @NotEmpty(message = "설명을 입력해주세요.")
+    @Length(min = 1, max = 450, message = "설명은 450자 이하로 입력해주세요.")
+    private String description;
+
+    @NotEmpty(message = "기간을 입력해주세요.")
+    private String duration;
+
+    @NotNull(message = "카테고리를 선택해주세요.")
+    private Category category;
+
+    @NotNull(message = "기간을 선택해주세요.")
+    private Period period;
+
+    @NotNull(message = "상태를 선택해주세요.")
+    private Status status;
+
+    private String thumbnail;
+    private String link;
+
+    @NotEmpty(message = "관련 기술을 선택해주세요.")
+    @Size(max = 20, message = "관련 기술은 20개 이하로 선택해주세요.")
+    private List<String> skills;
+}
+

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveUpdateDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveUpdateDTO.java
@@ -1,0 +1,42 @@
+package sequence.sequence_member.archive.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.hibernate.validator.constraints.Length;
+import sequence.sequence_member.global.enums.enums.Category;
+import sequence.sequence_member.global.enums.enums.Period;
+import sequence.sequence_member.global.enums.enums.Status;
+
+import java.util.List;
+
+@Getter
+public class ArchiveUpdateDTO {
+    @NotEmpty(message = "제목을 입력해주세요.")
+    @Length(min = 1, max = 40, message = "제목은 40자 이하로 입력해주세요.")
+    private String title;
+
+    @NotEmpty(message = "설명을 입력해주세요.")
+    @Length(min = 1, max = 450, message = "설명은 450자 이하로 입력해주세요.")
+    private String description;
+
+    @NotEmpty(message = "기간을 입력해주세요.")
+    private String duration;
+
+    @NotNull(message = "카테고리를 선택해주세요.")
+    private Category category;
+
+    @NotNull(message = "기간을 선택해주세요.")
+    private Period period;
+
+    @NotNull(message = "상태를 선택해주세요.")
+    private Status status;
+
+    private String thumbnail;
+    private String link;
+
+    @NotEmpty(message = "관련 기술을 선택해주세요.")
+    @Size(max = 20, message = "관련 기술은 20개 이하로 선택해주세요.")
+    private List<String> skills;
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/entity/Archive.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/entity/Archive.java
@@ -22,6 +22,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sequence.sequence_member.archive.dto.ArchiveUpdateDTO;
 import sequence.sequence_member.global.enums.enums.Category;
 import sequence.sequence_member.global.enums.enums.Period;
 import sequence.sequence_member.global.enums.enums.Status;
@@ -95,4 +96,16 @@ public class Archive extends BaseTimeEntity {
         }
         this.skills = String.join(",", skillList);
     }
-} 
+
+    // 아카이브 수정 시 사용
+    public void updateArchive(ArchiveUpdateDTO archiveUpdateDTO) {
+        this.title = archiveUpdateDTO.getTitle();
+        this.description = archiveUpdateDTO.getDescription();
+        this.duration = archiveUpdateDTO.getDuration();
+        this.category = archiveUpdateDTO.getCategory();
+        this.period = archiveUpdateDTO.getPeriod();
+        this.status = archiveUpdateDTO.getStatus();
+        this.thumbnail = archiveUpdateDTO.getThumbnail();
+        this.link = archiveUpdateDTO.getLink();
+    }
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/repository/ArchiveRegisterRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/repository/ArchiveRegisterRepository.java
@@ -1,0 +1,9 @@
+package sequence.sequence_member.archive.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import sequence.sequence_member.archive.entity.Archive;
+
+@Repository
+public interface ArchiveRegisterRepository extends JpaRepository<Archive, Long> {
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/repository/ArchiveRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/repository/ArchiveRepository.java
@@ -5,9 +5,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sequence.sequence_member.archive.entity.Archive;
 import sequence.sequence_member.global.enums.enums.Category;
+import java.util.Optional;
 
 public interface ArchiveRepository extends JpaRepository<Archive, Long> {
     // 기본 CRUD 메서드는 JpaRepository에서 제공
+
+    //아카이브 등록 후 Read
+    Optional<Archive> findById(Long id);
     
     // 카테고리별 검색 (페이지네이션)
     Page<Archive> findByCategory(Category category, Pageable pageable);

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import sequence.sequence_member.archive.dto.ArchiveOutputDTO;
 import sequence.sequence_member.archive.dto.ArchivePageResponseDTO;
 import sequence.sequence_member.archive.dto.ArchiveRegisterInputDTO;
+import sequence.sequence_member.archive.dto.ArchiveUpdateDTO;
 import sequence.sequence_member.archive.entity.Archive;
 import sequence.sequence_member.archive.repository.ArchiveRepository;
 import sequence.sequence_member.global.enums.enums.Category;
@@ -57,6 +58,45 @@ public class ArchiveService {
                 .modifiedDateTime(savedArchive.getModifiedDateTime())
                 .build();
     }
+
+    // 아카이브 등록 후 결과 조회
+    public ArchiveOutputDTO getArchiveById(Long archiveId) {
+        Archive archive = archiveRepository.findById(archiveId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 아카이브가 없습니다."));
+        return ArchiveOutputDTO.builder()
+                .id(archive.getId())
+                .title(archive.getTitle())
+                .description(archive.getDescription())
+                .duration(archive.getDuration())
+                .category(archive.getCategory())
+                .period(archive.getPeriod())
+                .status(archive.getStatus())
+                .thumbnail(archive.getThumbnail())
+                .link(archive.getLink())
+                .skills(archive.getSkillList())
+                .view(archive.getView())
+                .bookmark(archive.getBookmark())
+                .createdDateTime(archive.getCreatedDateTime())
+                .modifiedDateTime(archive.getModifiedDateTime())
+                .build();
+    }
+
+    // 아카이브 내용 수정
+    @Transactional
+    public void updateArchive(Long archiveId, ArchiveUpdateDTO archiveUpdateDTO) {
+        Archive archive = archiveRepository.findById(archiveId)
+                .orElseThrow(()-> new IllegalArgumentException("해당 아카이브가 없습니다."));
+        archive.updateArchive(archiveUpdateDTO);
+    }
+
+    // 아카이브 삭제
+    @Transactional
+    public void deleteArchive(Long archiveId) {
+        Archive archive = archiveRepository.findById(archiveId)
+                .orElseThrow(()-> new IllegalArgumentException("해당 아카이브가 없습니다."));
+        archiveRepository.delete(archive);
+    }
+
     
     // 전체 아카이브 목록 조회 (정렬 추가)
     public ArchivePageResponseDTO getAllArchives(int page, SortType sortType) {

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sequence.sequence_member.archive.dto.ArchiveOutputDTO;
 import sequence.sequence_member.archive.dto.ArchivePageResponseDTO;
+import sequence.sequence_member.archive.dto.ArchiveRegisterInputDTO;
 import sequence.sequence_member.archive.entity.Archive;
 import sequence.sequence_member.archive.repository.ArchiveRepository;
 import sequence.sequence_member.global.enums.enums.Category;
@@ -21,6 +22,33 @@ import sequence.sequence_member.global.exception.CanNotFindResourceException;
 public class ArchiveService {
     
     private final ArchiveRepository archiveRepository;
+
+    /**
+     * 프로젝트 등록
+     * @param archiveRegisterInputDTO
+     * @return archiveOutputDTO
+     */
+
+    public Long createArchive(ArchiveRegisterInputDTO archiveRegisterInputDTO) {
+        // Archive 엔티티 생성
+        Archive archive = Archive.builder()
+                .title(archiveRegisterInputDTO.getTitle())
+                .description(archiveRegisterInputDTO.getDescription())
+                .duration(archiveRegisterInputDTO.getDuration())
+                .category(archiveRegisterInputDTO.getCategory())
+                .period(archiveRegisterInputDTO.getPeriod())
+                .status(archiveRegisterInputDTO.getStatus())
+                .thumbnail(archiveRegisterInputDTO.getThumbnail())
+                .link(archiveRegisterInputDTO.getLink())
+                .skills(archiveRegisterInputDTO.getSkills().toString())
+                .build();
+
+        // 엔티티 저장
+        Archive savedArchive = archiveRepository.save(archive);
+        
+        // 저장된 엔티티 id 반환
+        return savedArchive.getId();
+    }
     
     // 전체 아카이브 목록 조회 (정렬 추가)
     public ArchivePageResponseDTO getAllArchives(int page, SortType sortType) {

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
@@ -23,14 +23,8 @@ public class ArchiveService {
     
     private final ArchiveRepository archiveRepository;
 
-    /**
-     * 프로젝트 등록
-     * @param archiveRegisterInputDTO
-     * @return archiveOutputDTO
-     */
-
-    public Long createArchive(ArchiveRegisterInputDTO archiveRegisterInputDTO) {
-        // Archive 엔티티 생성
+    @Transactional
+    public ArchiveOutputDTO createArchive(ArchiveRegisterInputDTO archiveRegisterInputDTO) {
         Archive archive = Archive.builder()
                 .title(archiveRegisterInputDTO.getTitle())
                 .description(archiveRegisterInputDTO.getDescription())
@@ -40,14 +34,28 @@ public class ArchiveService {
                 .status(archiveRegisterInputDTO.getStatus())
                 .thumbnail(archiveRegisterInputDTO.getThumbnail())
                 .link(archiveRegisterInputDTO.getLink())
-                .skills(archiveRegisterInputDTO.getSkills().toString())
                 .build();
 
-        // 엔티티 저장
+        archive.setSkillsFromList(archiveRegisterInputDTO.getSkills());
+
         Archive savedArchive = archiveRepository.save(archive);
-        
-        // 저장된 엔티티 id 반환
-        return savedArchive.getId();
+
+        return ArchiveOutputDTO.builder()
+                .id(savedArchive.getId())
+                .title(savedArchive.getTitle())
+                .description(savedArchive.getDescription())
+                .duration(savedArchive.getDuration())
+                .category(savedArchive.getCategory())
+                .period(savedArchive.getPeriod())
+                .status(savedArchive.getStatus())
+                .thumbnail(savedArchive.getThumbnail())
+                .link(savedArchive.getLink())
+                .skills(savedArchive.getSkillList())
+                .view(savedArchive.getView())
+                .bookmark(savedArchive.getBookmark())
+                .createdDateTime(savedArchive.getCreatedDateTime())
+                .modifiedDateTime(savedArchive.getModifiedDateTime())
+                .build();
     }
     
     // 전체 아카이브 목록 조회 (정렬 추가)


### PR DESCRIPTION
이번 PR에서는 아카이브(Archive) 엔티티의 Create, Read, Update, Delete(CRUD) 기능이 완전히 구현되었습니다.  
아래는 각 기능별 주요 내용입니다.

---

### 🛠 주요 변경 사항

#### ✅ **1. 아카이브 등록(Create)**
- **엔드포인트:** `POST /api/archive`
- **설명:** 사용자가 입력한 프로젝트 정보(제목, 설명, 기술 스택 등)를 통해 아카이브 데이터를 저장
- **주요 로직:**
  - `ArchiveRegisterInputDTO`를 통해 요청 데이터 검증
  - 등록 성공 시 응답 메시지 반환
- **테스트:** Postman으로 정상 등록 확인 완료

#### ✅ **2. 아카이브 조회(Read)**
- **특정 아카이브 조회:** 
  - **엔드포인트:** `GET /api/archive/{archiveId}`
  - **설명:** 특정 ID에 해당하는 아카이브 정보 반환
  - 잘못된 ID 요청 시 예외 처리 메시지 반환

#### ✅ **3. 아카이브 수정(Update)**
- **엔드포인트:** `PUT /api/archive/{archiveId}`
- **설명:** 특정 아카이브 데이터 수정
- **주요 로직:** 
  - `ArchiveUpdateDTO`를 통해 수정 요청 데이터 검증
  - 업데이트 성공 시 응답 메시지 반환
- **테스트:** Postman으로 수정 테스트 완료

#### ✅ **4. 아카이브 삭제(Delete)**
- **엔드포인트:** `DELETE /api/archive/{archiveId}`
- **설명:** 특정 ID에 해당하는 아카이브 데이터 삭제
- **주요 로직:** 
  - 삭제 성공 시 응답 메시지 반환
  - 잘못된 ID 요청 시 예외 메시지 처리
- **테스트:** Postman으로 삭제 테스트 완료

---

### ✅ 테스트 및 예외 처리 강화
- **정상 요청:** 모든 CRUD 기능 테스트 완료
- **예외 처리:** 잘못된 요청에 대해 예외 처리 로직 구현
  - 등록/수정 요청 시 유효성 검사 실패 처리
  - 존재하지 않는 ID 요청 예외 처리
