### PR TITLE
Feat/jaehwan/archive

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,9 +140,9 @@ jobs:
               -e MAX_FILE_SIZE=${{secrets.MAX_FILE_SIZE}} \
               -e MAX_REQUEST_SIZE=${{secrets.MAX_REQUEST_SIZE}} \
               -e DATABASE_DRIVER=org.mariadb.jdbc.Driver \
-              -e DATABASE_URL= ${{secrets.DATABASE_URL}} \
-              -e DATABASE_USERNAME = ${{secrets.DATABASE_USERNAME}} \
-              -e DATABASE_PASSWORD = ${{secrets.DATABASE_PASSWORD}} 
+              -e DATABASE_URL=${{secrets.DATABASE_URL}} \
+              -e DATABASE_USERNAME=${{secrets.DATABASE_USERNAME}} \
+              -e DATABASE_PASSWORD=${{secrets.DATABASE_PASSWORD}} 
               ${{secrets.DOCKER_USERNAME}}/sequence:latest
 
       

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
         uses: appleboy/ssh-action@v0.1.8
         with:
           host: ${{secrets.SERVER_HOST}}
-          username: ${{secrets.SERVER_USER}}
+          username: ${{secrets.SERVER_USERNAME}}
           key: ${{secrets.SERVER_SSH_KEY}}
           port: 22
           script: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,7 +142,7 @@ jobs:
               -e DATABASE_DRIVER=org.mariadb.jdbc.Driver \
               -e DATABASE_URL=${{secrets.DATABASE_URL}} \
               -e DATABASE_USERNAME=${{secrets.DATABASE_USERNAME}} \
-              -e DATABASE_PASSWORD=${{secrets.DATABASE_PASSWORD}} 
+              -e DATABASE_PASSWORD=${{secrets.DATABASE_PASSWORD}} \
               ${{secrets.DOCKER_USERNAME}}/sequence:latest
 
       

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/controller/TeamEvaluationController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/controller/TeamEvaluationController.java
@@ -5,11 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sequence.sequence_member.archive.dto.TeamEvaluationRequestDto;
-<<<<<<< HEAD
 import sequence.sequence_member.archive.entity.TeamEvaluation;
-=======
-import sequence.sequence_member.archive.dto.TeamEvaluationResponseDto;
->>>>>>> a02a9c7381dd303feb43d231b5be08815f0d712e
 import sequence.sequence_member.archive.service.TeamEvaluationService;
 import sequence.sequence_member.global.response.ApiResponseData;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,19 +13,13 @@ import sequence.sequence_member.member.dto.CustomUserDetails;
 import org.springframework.security.core.context.SecurityContextHolder;
 import sequence.sequence_member.global.response.Code;
 import sequence.sequence_member.global.enums.enums.Status;
-<<<<<<< HEAD
 import sequence.sequence_member.archive.dto.TeamEvaluationResponseDto;
-=======
->>>>>>> a02a9c7381dd303feb43d231b5be08815f0d712e
 
 import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Map;
-<<<<<<< HEAD
 import java.util.stream.Collectors;
-=======
->>>>>>> a02a9c7381dd303feb43d231b5be08815f0d712e
 
 @RestController
 @RequiredArgsConstructor
@@ -39,7 +29,6 @@ public class TeamEvaluationController {
     private final TeamEvaluationService teamEvaluationService;
 
     @PostMapping("/{archiveId}/evaluations")
-<<<<<<< HEAD
     public ResponseEntity<?> createTeamEvaluation(
             @PathVariable Long archiveId,
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -56,35 +45,8 @@ public class TeamEvaluationController {
             @PathVariable Long archiveId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
     
-        List<TeamEvaluationResponseDto> responseDtos = teamEvaluationService.getTeamEvaluations(archiveId, userDetails.getUsername());
-        return ResponseEntity.ok(ApiResponseData.success(responseDtos));
-=======
-    public ResponseEntity<ApiResponseData<?>> createTeamEvaluation(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long archiveId,
-            @RequestBody @Valid TeamEvaluationRequestDto requestDto) {
-            
-        System.out.println("Authentication: " + SecurityContextHolder.getContext().getAuthentication());
-        System.out.println("UserDetails: " + userDetails);
-        
-        TeamEvaluationResponseDto responseDto = teamEvaluationService.createTeamEvaluation(
-            archiveId,
-            userDetails.getUsername(),
-            requestDto
-        );
-        
-        // 이미 평가가 존재하는 경우
-        if (responseDto == null) {
-            return ResponseEntity
-                    .status(Code.ALREADY_EXISTS.getStatus())
-                    .body(ApiResponseData.of(Code.ALREADY_EXISTS.getCode(), "이미 평가한 팀원입니다.", null));
-        }
-        
-        // 새로운 평가인 경우
-        return ResponseEntity
-                .status(Code.CREATED.getStatus())
-                .body(ApiResponseData.of(Code.CREATED.getCode(), "팀원 평가가 성공적으로 저장되었습니다.", responseDto));
->>>>>>> a02a9c7381dd303feb43d231b5be08815f0d712e
+        List<TeamEvaluationResponseDto> evaluations = teamEvaluationService.getTeamEvaluations(archiveId, userDetails.getUsername());
+        return ResponseEntity.ok(ApiResponseData.success(evaluations));
     }
 
     @GetMapping(

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/controller/TeamEvaluationController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/controller/TeamEvaluationController.java
@@ -1,0 +1,70 @@
+package sequence.sequence_member.archive.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sequence.sequence_member.archive.dto.TeamEvaluationRequestDto;
+import sequence.sequence_member.archive.entity.TeamEvaluation;
+import sequence.sequence_member.archive.service.TeamEvaluationService;
+import sequence.sequence_member.global.response.ApiResponseData;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import sequence.sequence_member.member.dto.CustomUserDetails;
+import org.springframework.security.core.context.SecurityContextHolder;
+import sequence.sequence_member.global.response.Code;
+import sequence.sequence_member.global.enums.enums.Status;
+import sequence.sequence_member.archive.dto.TeamEvaluationResponseDto;
+
+import jakarta.validation.Valid;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/archive")
+public class TeamEvaluationController {
+
+    private final TeamEvaluationService teamEvaluationService;
+
+    @PostMapping("/{archiveId}/evaluations")
+    public ResponseEntity<?> createTeamEvaluation(
+            @PathVariable Long archiveId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody TeamEvaluationRequestDto requestDto) {
+            
+        teamEvaluationService.createTeamEvaluation(archiveId, userDetails.getUsername(), requestDto);
+        return ResponseEntity
+                .status(Code.CREATED.getStatus())
+                .body(ApiResponseData.of(Code.CREATED.getCode(), "팀원 평가가 완료되었습니다.", null));
+    }
+
+    @GetMapping("/{archiveId}/evaluations")
+    public ResponseEntity<?> getTeamEvaluations(
+            @PathVariable Long archiveId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+    
+        List<TeamEvaluationResponseDto> responseDtos = teamEvaluationService.getTeamEvaluations(archiveId, userDetails.getUsername());
+        return ResponseEntity.ok(ApiResponseData.success(responseDtos));
+    }
+
+    @GetMapping(
+        value = "/{archiveId}/evaluations/status",
+        produces = "application/json"
+    )
+    public ResponseEntity<ApiResponseData<Map<String, Status>>> getEvaluationStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long archiveId) {
+        Map<String, Status> evaluationStatus = teamEvaluationService.getEvaluationStatus(archiveId, userDetails.getUsername());
+        return ResponseEntity.ok(ApiResponseData.success(evaluationStatus));
+    }
+
+    @GetMapping("/{archiveId}/team-members")
+    public ResponseEntity<ApiResponseData<List<String>>> getTeamMembers(
+            @PathVariable Long archiveId) {
+        // 팀원의 목록을 가져오는 서비스 호출 (teamEvaluationService가 아닌 다른 서비스일 수 있음)
+        List<String> evaluators = teamEvaluationService.getEvaluators(archiveId);
+        return ResponseEntity.ok(ApiResponseData.success(evaluators));
+    }
+} 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveOutputDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveOutputDTO.java
@@ -18,17 +18,27 @@ import java.util.List;
 public class ArchiveOutputDTO {
     private Long id;
     private String title;
-    private String description;
+    private String description; 
     private String duration;
     private Category category;
     private Period period;
-    private Status status;
     private String thumbnail;
     private String link;
     private List<String> skills;
     private List<String> imgUrls;
     private Integer view;
     private Integer bookmark;
+    private List<ArchiveMemberDTO> members;
     private LocalDateTime createdDateTime;
     private LocalDateTime modifiedDateTime;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ArchiveMemberDTO {
+        private String username;
+        private String nickname;
+        private String role;
+    }
 } 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveRegisterInputDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveRegisterInputDTO.java
@@ -15,9 +15,9 @@ import sequence.sequence_member.global.enums.enums.Status;
 import java.util.List;
 
 @Getter
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class ArchiveRegisterInputDTO {
 
     @NotEmpty(message = "제목을 입력해주세요.")
@@ -37,8 +37,6 @@ public class ArchiveRegisterInputDTO {
     @NotNull(message = "기간을 선택해주세요.")
     private Period period;
 
-    @NotNull(message = "상태를 선택해주세요.")
-    private Status status;
 
     private String thumbnail;
     private String link;
@@ -46,5 +44,15 @@ public class ArchiveRegisterInputDTO {
     @NotEmpty(message = "관련 기술을 선택해주세요.")
     @Size(max = 20, message = "관련 기술은 20개 이하로 선택해주세요.")
     private List<String> skills;
+
+    private List<ArchiveMemberDTO> archiveMembers;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ArchiveMemberDTO {
+        private String username;
+        private String role;
+    }
 }
 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveUpdateDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveUpdateDTO.java
@@ -39,4 +39,17 @@ public class ArchiveUpdateDTO {
     @NotEmpty(message = "관련 기술을 선택해주세요.")
     @Size(max = 20, message = "관련 기술은 20개 이하로 선택해주세요.")
     private List<String> skills;
+
+    private List<String> imgUrls;
+
+    @NotEmpty(message = "팀원 정보를 입력해주세요.")
+    private List<ArchiveMemberDTO> archiveMembers;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ArchiveMemberDTO {
+        private String username;
+        private String role;
+    }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/dto/TeamEvaluationRequestDto.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/dto/TeamEvaluationRequestDto.java
@@ -1,0 +1,34 @@
+package sequence.sequence_member.archive.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.util.List;
+import jakarta.validation.Valid;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamEvaluationRequestDto {
+    @NotNull(message = "평가 목록은 필수입니다.")
+    @Valid
+    private List<EvaluationItem> evaluations;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EvaluationItem {
+        @NotNull(message = "평가 받는 팀원의 username은 필수입니다.")
+        private String evaluatedUserName;
+        
+        @NotNull(message = "피드백 내용은 필수입니다.")
+        private String feedback;
+        
+        @NotNull(message = "키워드는 필수입니다.")
+        private List<String> keyword;
+    }
+} 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/dto/TeamEvaluationResponseDto.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/dto/TeamEvaluationResponseDto.java
@@ -1,0 +1,56 @@
+package sequence.sequence_member.archive.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import sequence.sequence_member.archive.entity.TeamEvaluation;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamEvaluationResponseDto {
+    private EvaluatorInfo evaluator;
+    private List<EvaluatedInfo> evaluated;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EvaluatorInfo {
+        private String username;
+        private String role;
+        private String profileImg;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EvaluatedInfo {
+        private String username;
+        private String role;
+        private String profileImg;
+    }
+
+    public static TeamEvaluationResponseDto from(TeamEvaluation evaluation) {
+        return TeamEvaluationResponseDto.builder()
+                .evaluator(EvaluatorInfo.builder()
+                    .username(evaluation.getEvaluator().getMember().getUsername())
+                    .role(evaluation.getEvaluator().getRole())
+                    .profileImg(evaluation.getEvaluator().getMember().getProfileImg())
+                    .build())
+                .evaluated((List<EvaluatedInfo>) EvaluatedInfo.builder()
+                    .username(evaluation.getEvaluated().getMember().getUsername())
+                    .role(evaluation.getEvaluated().getRole())
+                    .profileImg(evaluation.getEvaluated().getMember().getProfileImg())
+                    .build())
+                .build();
+    }
+} 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/entity/Archive.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/entity/Archive.java
@@ -22,11 +22,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import sequence.sequence_member.archive.dto.ArchiveUpdateDTO;
 import sequence.sequence_member.global.enums.enums.Category;
 import sequence.sequence_member.global.enums.enums.Period;
 import sequence.sequence_member.global.enums.enums.Status;
 import sequence.sequence_member.global.utils.BaseTimeEntity;
+import sequence.sequence_member.archive.dto.ArchiveUpdateDTO;
 
 @Entity
 @Getter
@@ -115,7 +115,7 @@ public class Archive extends BaseTimeEntity {
         this.imgUrl = String.join(",", imageUrlList);
     }
 
-    // 아카이브 수정 시 사용
+    // 아카이브 업데이트 메서드 추가
     public void updateArchive(ArchiveUpdateDTO archiveUpdateDTO) {
         this.title = archiveUpdateDTO.getTitle();
         this.description = archiveUpdateDTO.getDescription();
@@ -125,5 +125,7 @@ public class Archive extends BaseTimeEntity {
         this.status = archiveUpdateDTO.getStatus();
         this.thumbnail = archiveUpdateDTO.getThumbnail();
         this.link = archiveUpdateDTO.getLink();
+        setSkillsFromList(archiveUpdateDTO.getSkills());
+        setImageUrlsFromList(archiveUpdateDTO.getImgUrls());
     }
-}
+} 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/entity/TeamEvaluation.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/entity/TeamEvaluation.java
@@ -1,0 +1,53 @@
+package sequence.sequence_member.archive.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sequence.sequence_member.global.utils.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "team_evaluation")
+public class TeamEvaluation extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "evaluator_id", nullable = false)
+    private ArchiveMember evaluator;    // 평가자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "evaluated_id", nullable = false)
+    private ArchiveMember evaluated;    // 피평가자
+
+    @Column(nullable = true)
+    private String feedback;            // 피드백 내용
+
+    @Column(columnDefinition = "json", nullable = true)
+    private String keyword;             // 키워드 (JSON 형태로 저장)
+
+    @Column(nullable = true)
+    private String lineFeedback;    // 한줄 피드백 필드 추가
+
+    // 같은 Archive 내의 멤버끼리만 평가할 수 있도록 검증
+    public boolean validateSameArchive() {
+        return evaluator.getArchive().getId().equals(evaluated.getArchive().getId());
+    }
+
+    // 자기 자신을 평가할 수 없도록 검증
+    public boolean validateSelfEvaluation() {
+        return !evaluator.getId().equals(evaluated.getId());
+    }
+
+    public String getLineFeedback() {
+        return this.lineFeedback;
+    }
+} 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/repository/ArchiveMemberRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/repository/ArchiveMemberRepository.java
@@ -1,0 +1,19 @@
+package sequence.sequence_member.archive.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sequence.sequence_member.archive.entity.ArchiveMember;
+import sequence.sequence_member.archive.entity.Archive;
+import sequence.sequence_member.member.entity.MemberEntity;
+import java.util.List;
+
+public interface ArchiveMemberRepository extends JpaRepository<ArchiveMember, Long> {
+    // 기본적인 CRUD 메서드는 JpaRepository에서 제공됨
+
+    // 아카이브와 멤버 ID로 아카이브 멤버 찾기
+    ArchiveMember findByArchiveAndMemberId(Archive archive, Long memberId);
+
+    // 멤버와 아카이브 ID로 아카이브 멤버 찾기
+    ArchiveMember findByMemberAndArchive_Id(MemberEntity member, Long archiveId);
+
+    List<ArchiveMember> findAllByArchiveId(Long archiveId);
+} 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/repository/TeamEvaluationRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/repository/TeamEvaluationRepository.java
@@ -1,0 +1,35 @@
+package sequence.sequence_member.archive.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import sequence.sequence_member.archive.entity.Archive;
+import sequence.sequence_member.archive.entity.ArchiveMember;
+import sequence.sequence_member.archive.entity.TeamEvaluation;
+
+import java.util.List;
+
+public interface TeamEvaluationRepository extends JpaRepository<TeamEvaluation, Long> {
+    
+    // 평가자가 특정 피평가자를 평가했는지 확인
+    boolean existsByEvaluatorAndEvaluated(ArchiveMember evaluator, ArchiveMember evaluated);
+    
+    // 특정 아카이브의 모든 팀원 간 상호평가가 완료되었는지 확인
+    @Query("SELECT COUNT(te) = " +
+           "(SELECT COUNT(am1) * (COUNT(am2) - 1) FROM ArchiveMember am1, ArchiveMember am2 " +
+           "WHERE am1.archive = :archive AND am2.archive = :archive AND am1 != am2) " +
+           "FROM TeamEvaluation te " +
+           "WHERE te.evaluator.archive = :archive")
+    boolean isAllEvaluationCompletedInArchive(@Param("archive") Archive archive);
+    
+    // 평가자와 피평가자로 평가 정보 조회
+    TeamEvaluation findByEvaluatorAndEvaluated(ArchiveMember evaluator, ArchiveMember evaluated);
+    
+    // 특정 멤버가 받은 평가 수 조회
+    long countByEvaluated(ArchiveMember evaluated);
+
+    @Query("SELECT DISTINCT t.evaluator FROM TeamEvaluation t WHERE t.evaluator.archive = :archive")
+    List<ArchiveMember> findDistinctEvaluatorsByArchive(Archive archive);
+
+    List<TeamEvaluation> findAllByEvaluatorAndEvaluator_Archive_Id(ArchiveMember evaluator, Long archiveId);
+} 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
@@ -16,6 +16,15 @@ import sequence.sequence_member.archive.repository.ArchiveRepository;
 import sequence.sequence_member.global.enums.enums.Category;
 import sequence.sequence_member.global.enums.enums.SortType;
 import sequence.sequence_member.global.exception.CanNotFindResourceException;
+import sequence.sequence_member.member.entity.MemberEntity;
+import sequence.sequence_member.member.repository.MemberRepository;
+import sequence.sequence_member.archive.entity.ArchiveMember;
+import sequence.sequence_member.archive.repository.ArchiveMemberRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import sequence.sequence_member.global.enums.enums.Status;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,62 +32,48 @@ import sequence.sequence_member.global.exception.CanNotFindResourceException;
 public class ArchiveService {
     
     private final ArchiveRepository archiveRepository;
+    private final MemberRepository memberRepository;
+    private final ArchiveMemberRepository archiveMemberRepository;
 
     @Transactional
-    public ArchiveOutputDTO createArchive(ArchiveRegisterInputDTO archiveRegisterInputDTO) {
+    public ArchiveOutputDTO createArchive(ArchiveRegisterInputDTO dto) {
         Archive archive = Archive.builder()
-                .title(archiveRegisterInputDTO.getTitle())
-                .description(archiveRegisterInputDTO.getDescription())
-                .duration(archiveRegisterInputDTO.getDuration())
-                .category(archiveRegisterInputDTO.getCategory())
-                .period(archiveRegisterInputDTO.getPeriod())
-                .status(archiveRegisterInputDTO.getStatus())
-                .thumbnail(archiveRegisterInputDTO.getThumbnail())
-                .link(archiveRegisterInputDTO.getLink())
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .duration(dto.getDuration())
+                .category(dto.getCategory())
+                .period(dto.getPeriod())
+                .status(Status.평가전)
+                .thumbnail(dto.getThumbnail())
+                .link(dto.getLink())
                 .build();
 
-        archive.setSkillsFromList(archiveRegisterInputDTO.getSkills());
-
+        archive.setSkillsFromList(dto.getSkills());
         Archive savedArchive = archiveRepository.save(archive);
 
-        return ArchiveOutputDTO.builder()
-                .id(savedArchive.getId())
-                .title(savedArchive.getTitle())
-                .description(savedArchive.getDescription())
-                .duration(savedArchive.getDuration())
-                .category(savedArchive.getCategory())
-                .period(savedArchive.getPeriod())
-                .status(savedArchive.getStatus())
-                .thumbnail(savedArchive.getThumbnail())
-                .link(savedArchive.getLink())
-                .skills(savedArchive.getSkillList())
-                .view(savedArchive.getView())
-                .bookmark(savedArchive.getBookmark())
-                .createdDateTime(savedArchive.getCreatedDateTime())
-                .modifiedDateTime(savedArchive.getModifiedDateTime())
+        // 아카이브 멤버 등록
+        for (ArchiveRegisterInputDTO.ArchiveMemberDTO memberDto : dto.getArchiveMembers()) {
+            MemberEntity member = memberRepository.findByUsername(memberDto.getUsername())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다: " + memberDto.getUsername()));
+
+            ArchiveMember archiveMember = ArchiveMember.builder()
+                .archive(savedArchive)
+                .member(member)
+                .role(memberDto.getRole())
                 .build();
+
+            archiveMemberRepository.save(archiveMember);
+        }
+
+        return convertToDTO(savedArchive);
     }
 
     // 아카이브 등록 후 결과 조회
     public ArchiveOutputDTO getArchiveById(Long archiveId) {
         Archive archive = archiveRepository.findById(archiveId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 아카이브가 없습니다."));
-        return ArchiveOutputDTO.builder()
-                .id(archive.getId())
-                .title(archive.getTitle())
-                .description(archive.getDescription())
-                .duration(archive.getDuration())
-                .category(archive.getCategory())
-                .period(archive.getPeriod())
-                .status(archive.getStatus())
-                .thumbnail(archive.getThumbnail())
-                .link(archive.getLink())
-                .skills(archive.getSkillList())
-                .view(archive.getView())
-                .bookmark(archive.getBookmark())
-                .createdDateTime(archive.getCreatedDateTime())
-                .modifiedDateTime(archive.getModifiedDateTime())
-                .build();
+        
+        return convertToDTO(archive);
     }
 
     // 아카이브 내용 수정
@@ -86,6 +81,26 @@ public class ArchiveService {
     public void updateArchive(Long archiveId, ArchiveUpdateDTO archiveUpdateDTO) {
         Archive archive = archiveRepository.findById(archiveId)
                 .orElseThrow(()-> new IllegalArgumentException("해당 아카이브가 없습니다."));
+        
+        // 기존 팀원 정보 삭제
+        archiveMemberRepository.deleteAllByArchive(archive);
+        
+        // 새로운 팀원 정보 등록
+        for (ArchiveUpdateDTO.ArchiveMemberDTO memberDto : archiveUpdateDTO.getArchiveMembers()) {
+            MemberEntity member = memberRepository.findByUsername(memberDto.getUsername())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, 
+                    "존재하지 않는 사용자입니다: " + memberDto.getUsername()));
+
+            ArchiveMember archiveMember = ArchiveMember.builder()
+                .archive(archive)
+                .member(member)
+                .role(memberDto.getRole())
+                .build();
+
+            archiveMemberRepository.save(archiveMember);
+        }
+        
+        // 나머지 정보 업데이트
         archive.updateArchive(archiveUpdateDTO);
     }
 
@@ -149,6 +164,14 @@ public class ArchiveService {
 
     // Archive 엔티티를 DTO로 변환
     private ArchiveOutputDTO convertToDTO(Archive archive) {
+        List<ArchiveOutputDTO.ArchiveMemberDTO> memberDTOs = archive.getArchiveMembers().stream()
+            .map(archiveMember -> ArchiveOutputDTO.ArchiveMemberDTO.builder()
+                .username(archiveMember.getMember().getUsername())
+                .nickname(archiveMember.getMember().getNickname())
+                .role(archiveMember.getRole())
+                .build())
+            .collect(Collectors.toList());
+
         return ArchiveOutputDTO.builder()
                 .id(archive.getId())
                 .title(archive.getTitle())
@@ -156,13 +179,13 @@ public class ArchiveService {
                 .duration(archive.getDuration())
                 .category(archive.getCategory())
                 .period(archive.getPeriod())
-                .status(archive.getStatus()) 
                 .thumbnail(archive.getThumbnail())
                 .link(archive.getLink())
                 .skills(archive.getSkillList())
                 .imgUrls(archive.getImageUrlsAsList())
                 .view(archive.getView())
                 .bookmark(archive.getBookmark())
+                .members(memberDTOs)
                 .createdDateTime(archive.getCreatedDateTime())
                 .modifiedDateTime(archive.getModifiedDateTime())
                 .build();

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
@@ -81,26 +81,6 @@ public class ArchiveService {
     public void updateArchive(Long archiveId, ArchiveUpdateDTO archiveUpdateDTO) {
         Archive archive = archiveRepository.findById(archiveId)
                 .orElseThrow(()-> new IllegalArgumentException("해당 아카이브가 없습니다."));
-        
-        // 기존 팀원 정보 삭제
-        archiveMemberRepository.deleteAllByArchive(archive);
-        
-        // 새로운 팀원 정보 등록
-        for (ArchiveUpdateDTO.ArchiveMemberDTO memberDto : archiveUpdateDTO.getArchiveMembers()) {
-            MemberEntity member = memberRepository.findByUsername(memberDto.getUsername())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, 
-                    "존재하지 않는 사용자입니다: " + memberDto.getUsername()));
-
-            ArchiveMember archiveMember = ArchiveMember.builder()
-                .archive(archive)
-                .member(member)
-                .role(memberDto.getRole())
-                .build();
-
-            archiveMemberRepository.save(archiveMember);
-        }
-        
-        // 나머지 정보 업데이트
         archive.updateArchive(archiveUpdateDTO);
     }
 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/TeamEvaluationService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/TeamEvaluationService.java
@@ -1,0 +1,199 @@
+package sequence.sequence_member.archive.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sequence.sequence_member.archive.dto.TeamEvaluationRequestDto;
+import sequence.sequence_member.archive.entity.ArchiveMember;
+import sequence.sequence_member.archive.entity.TeamEvaluation;
+import sequence.sequence_member.archive.repository.TeamEvaluationRepository;
+import sequence.sequence_member.global.enums.enums.Status;
+import sequence.sequence_member.global.exception.BAD_REQUEST_EXCEPTION;
+import sequence.sequence_member.archive.repository.ArchiveMemberRepository;
+import sequence.sequence_member.archive.entity.Archive;
+import sequence.sequence_member.archive.repository.ArchiveRepository;
+import sequence.sequence_member.member.entity.MemberEntity;
+import sequence.sequence_member.member.repository.MemberRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import sequence.sequence_member.global.exception.ArchiveNotFoundException;
+import java.util.stream.Collectors;
+import sequence.sequence_member.archive.dto.TeamEvaluationResponseDto;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamEvaluationService {
+
+    private final TeamEvaluationRepository teamEvaluationRepository;
+    private final ArchiveMemberRepository archiveMemberRepository;
+    private final ArchiveRepository archiveRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void createTeamEvaluation(
+            Long archiveId,
+            String username,
+            TeamEvaluationRequestDto requestDto) {
+            
+        // archive 존재 여부 먼저 확인
+        Archive archive = archiveRepository.findById(archiveId)
+            .orElseThrow(() -> new ArchiveNotFoundException("아카이브 정보를 찾을 수 없습니다."));
+            
+        // username으로 멤버 찾기
+        MemberEntity member = memberRepository.findByUsername(username)
+            .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
+            
+        // 평가자의 ArchiveMember 정보 조회
+        ArchiveMember evaluator = archiveMemberRepository.findByMemberAndArchive_Id(member, archiveId);
+        if (evaluator == null) {
+            throw new BAD_REQUEST_EXCEPTION("해당 아카이브의 멤버가 아닙니다.");
+        }
+
+        for (TeamEvaluationRequestDto.EvaluationItem evaluation : requestDto.getEvaluations()) {
+            // 피평가자 찾기
+            MemberEntity evaluatedMember = memberRepository.findByUsername(evaluation.getEvaluatedUserName())
+                .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("피평가자를 찾을 수 없습니다: " + evaluation.getEvaluatedUserName()));
+            
+            ArchiveMember evaluated = archiveMemberRepository.findByMemberAndArchive_Id(evaluatedMember, archiveId);
+            if (evaluated == null) {
+                throw new BAD_REQUEST_EXCEPTION("피평가자가 해당 아카이브의 멤버가 아닙니다: " + evaluation.getEvaluatedUserName());
+            }
+
+            // 이미 평가했는지 확인
+            if (teamEvaluationRepository.existsByEvaluatorAndEvaluated(evaluator, evaluated)) {
+                throw new BAD_REQUEST_EXCEPTION("이미 평가를 완료했습니다: " + evaluation.getEvaluatedUserName());
+            }
+
+            // 키워드 리스트를 JSON 배열 형식으로 변환
+            String keywordJson = "[\"" + String.join("\",\"", evaluation.getKeyword()) + "\"]";
+
+            // 팀 평가 엔티티 생성 및 검증
+            TeamEvaluation teamEvaluation = TeamEvaluation.builder()
+                    .evaluator(evaluator)
+                    .evaluated(evaluated)
+                    .feedback(evaluation.getFeedback())
+                    .keyword(keywordJson)
+                    .build();
+
+            if (!teamEvaluation.validateSameArchive()) {
+                throw new BAD_REQUEST_EXCEPTION("같은 아카이브의 멤버만 평가할 수 있습니다: " + evaluation.getEvaluatedUserName());
+            }
+
+            if (!teamEvaluation.validateSelfEvaluation()) {
+                throw new BAD_REQUEST_EXCEPTION("자기 자신은 평가할 수 없습니다: " + evaluation.getEvaluatedUserName());
+            }
+
+            teamEvaluationRepository.save(teamEvaluation);
+        }
+    }
+
+    // 아카이브의 모든 평가 완료 여부 확인 메소드 수정
+    public boolean isAllEvaluationCompleted(Long archiveId, String username) {
+        // username으로 멤버 찾기
+        MemberEntity member = memberRepository.findByUsername(username)
+            .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
+            
+        // 평가자의 ArchiveMember 정보 조회
+        ArchiveMember archiveMember = archiveMemberRepository.findByMemberAndArchive_Id(member, archiveId);
+        if (archiveMember == null) {
+            throw new BAD_REQUEST_EXCEPTION("해당 아카이브의 멤버가 아닙니다.");
+        }
+
+        Archive archive = archiveRepository.findById(archiveId)
+            .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("아카이브 정보를 찾을 수 없습니다."));
+        return teamEvaluationRepository.isAllEvaluationCompletedInArchive(archive);
+    }
+
+    public Map<String, Status> getEvaluationStatus(Long archiveId, String username) {
+        // username으로 멤버 찾기
+        MemberEntity member = memberRepository.findByUsername(username)
+            .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
+            
+        // 평가자의 ArchiveMember 정보 조회
+        ArchiveMember evaluator = archiveMemberRepository.findByMemberAndArchive_Id(member, archiveId);
+        if (evaluator == null) {
+            throw new BAD_REQUEST_EXCEPTION("해당 아카이브의 멤버가 아닙니다.");
+        }
+
+        // 아카이브의 모든 멤버 조회
+        List<ArchiveMember> archiveMembers = archiveMemberRepository.findAllByArchiveId(archiveId);
+        Map<String, Status> statusMap = new HashMap<>();
+
+        // 각 팀원별로 평가 상태 확인
+        for (ArchiveMember archiveMember : archiveMembers) {
+            int totalMembersToEvaluate = archiveMembers.size() - 1; // 자신 제외
+            int evaluatedCount = 0;
+            
+            // 해당 팀원이 다른 팀원들을 평가했는지 확인
+            for (ArchiveMember targetMember : archiveMembers) {
+                if (archiveMember.equals(targetMember)) {
+                    continue;  // 자기 자신은 건너뛰기
+                }
+
+                boolean hasEvaluated = teamEvaluationRepository.existsByEvaluatorAndEvaluated(archiveMember, targetMember);
+                if (hasEvaluated) {
+                    evaluatedCount++;
+                }
+            }
+
+            // 해당 팀원이 모든 팀원을 평가했는지 확인
+            Status memberStatus = (evaluatedCount == totalMembersToEvaluate) ? Status.평가완료 : Status.평가전;
+            statusMap.put(archiveMember.getMember().getNickname(), memberStatus);
+        }
+
+        return statusMap;
+    }
+
+    public List<String> getEvaluators(Long archiveId) {
+        Archive archive = archiveRepository.findById(archiveId)
+                .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("아카이브 정보를 찾을 수 없습니다."));
+
+        // 해당 아카이브에서 평가를 진행한 평가자들의 목록 조회
+        List<ArchiveMember> evaluators = teamEvaluationRepository.findDistinctEvaluatorsByArchive(archive);
+
+        // 평가자들의 사용자명 리스트로 변환하여 반환
+        return evaluators.stream()
+                .map(evaluator -> evaluator.getMember().getUsername())
+                .toList();
+    }
+
+    public List<TeamEvaluationResponseDto> getTeamEvaluations(Long archiveId, String username) {
+        // archive 존재 여부 확인
+        Archive archive = archiveRepository.findById(archiveId)
+            .orElseThrow(() -> new ArchiveNotFoundException("아카이브 정보를 찾을 수 없습니다."));
+        
+        // username으로 멤버 찾기
+        MemberEntity member = memberRepository.findByUsername(username)
+            .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
+            
+        // 평가자의 ArchiveMember 정보 조회
+        ArchiveMember evaluator = archiveMemberRepository.findByMemberAndArchive_Id(member, archiveId);
+        if (evaluator == null) {
+            throw new BAD_REQUEST_EXCEPTION("해당 아카이브의 멤버가 아닙니다.");
+        }
+
+        // 아카이브의 모든 멤버 조회
+        List<ArchiveMember> allMembers = archiveMemberRepository.findAllByArchiveId(archiveId);
+        
+        // 평가 대상 목록 생성 (자신 제외)
+        List<TeamEvaluationResponseDto.EvaluatedInfo> evaluatedList = allMembers.stream()
+            .filter(archiveMember -> !archiveMember.getId().equals(evaluator.getId()))
+            .map(evaluated -> TeamEvaluationResponseDto.EvaluatedInfo.builder()
+                .username(evaluated.getMember().getUsername())
+                .role(evaluated.getRole())
+                .profileImg(evaluated.getMember().getProfileImg())
+                .build())
+            .collect(Collectors.toList());
+
+        return List.of(TeamEvaluationResponseDto.builder()
+            .evaluator(TeamEvaluationResponseDto.EvaluatorInfo.builder()
+                .username(evaluator.getMember().getUsername())
+                .role(evaluator.getRole())
+                .profileImg(evaluator.getMember().getProfileImg())
+                .build())
+            .evaluated(evaluatedList)
+            .build());
+    }
+} 

--- a/sequence_member/src/main/java/sequence/sequence_member/global/exception/ArchiveNotFoundException.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/exception/ArchiveNotFoundException.java
@@ -1,0 +1,7 @@
+package sequence.sequence_member.global.exception;
+
+public class ArchiveNotFoundException extends RuntimeException {
+    public ArchiveNotFoundException(String message) {
+        super(message);
+    }
+} 

--- a/sequence_member/src/main/java/sequence/sequence_member/global/exception/BAD_REQUEST_EXCEPTION.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/exception/BAD_REQUEST_EXCEPTION.java
@@ -1,0 +1,7 @@
+package sequence.sequence_member.global.exception;
+
+public class BAD_REQUEST_EXCEPTION extends RuntimeException {
+    public BAD_REQUEST_EXCEPTION(String message) {
+        super(message);
+    }
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/global/exception/BadRequestExeption.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/exception/BadRequestExeption.java
@@ -1,7 +1,0 @@
-package sequence.sequence_member.global.exception;
-
-public class BadRequestExeption extends RuntimeException {
-    public BadRequestExeption(String message) {
-        super(message);
-    }
-}

--- a/sequence_member/src/main/java/sequence/sequence_member/global/exception/GlobalExceptionHandler.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/exception/GlobalExceptionHandler.java
@@ -92,10 +92,17 @@ public class GlobalExceptionHandler {
     }
 
     // BadRequestException 예외 처리
-    @ExceptionHandler(BadRequestExeption.class)
-    public ResponseEntity<ApiResponseData<String>> handleCustomNotFoundException(BadRequestExeption ex){
+    @ExceptionHandler(BAD_REQUEST_EXCEPTION.class)
+    public ResponseEntity<ApiResponseData<String>> handleCustomNotFoundException(BAD_REQUEST_EXCEPTION ex){
         Code code = Code.BAD_REQUEST;
         // 반환할 메시지와 HTTP 상태 코드 설정
         return ResponseEntity.status(code.getStatus()).body(ApiResponseData.of(code.getCode(), code.getMessage()+": "+ ex.getMessage(),null));
+    }
+
+    @ExceptionHandler(ArchiveNotFoundException.class)
+    public ResponseEntity<ApiResponseData<String>> handleArchiveNotFoundException(ArchiveNotFoundException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponseData.of(Code.CAN_NOT_FIND_RESOURCE.getCode(), ex.getMessage(), null));
     }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/global/response/Code.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/response/Code.java
@@ -14,6 +14,8 @@ public enum Code {
      * 성공 0번대
      */
     SUCCESS(HttpStatus.OK, 200, "성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, 201, "성공적으로 생성되었습니다."),
+    ALREADY_EXISTS(HttpStatus.OK, 202, "이미 존재하는 리소스입니다."),
 
     /**
      * VALIDATION 관련 100번대

--- a/sequence_member/src/main/java/sequence/sequence_member/member/config/SecurityConfig.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/config/SecurityConfig.java
@@ -100,6 +100,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth)->auth
                         .requestMatchers("/api/login", "/api/users/join", "/api/token", "/api/users/check_username", "/api/users/check_email", "/api/users/check_nickname").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/projects/**").permitAll()
+                        .requestMatchers("/api/archive/*/evaluations/**").authenticated()
                         .requestMatchers("/api/archive/**").permitAll()
                         .requestMatchers("/error").permitAll() // 예외 처리 로직 없을 때 Tomcat이 포워딩 하는 경로 접근 허용하여 예외 메세지 잘 전달되도록 허용
                         .anyRequest().authenticated());

--- a/sequence_member/src/main/java/sequence/sequence_member/member/service/InviteAccessService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/service/InviteAccessService.java
@@ -6,7 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import sequence.sequence_member.global.exception.BadRequestExeption;
+import sequence.sequence_member.global.exception.BAD_REQUEST_EXCEPTION;
 import sequence.sequence_member.global.exception.UserNotFindException;
 import sequence.sequence_member.member.dto.AcceptProjectOutputDTO;
 import sequence.sequence_member.member.dto.CustomUserDetails;
@@ -55,7 +55,7 @@ public class InviteAccessService {
     @Transactional
     public void acceptInvite(CustomUserDetails customUserDetails, Long projectInvitedMemberId){
         MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElseThrow(() -> new UserNotFindException("해당 유저가 존재하지 않습니다."));
-        ProjectInvitedMember projectInvitedMember = projectInvitedMemberRepository.findByIdAndMemberId(projectInvitedMemberId,member.getId()).orElseThrow(() -> new BadRequestExeption("해당 프로젝트 초대가 유효하지 않습니다."));
+        ProjectInvitedMember projectInvitedMember = projectInvitedMemberRepository.findByIdAndMemberId(projectInvitedMemberId,member.getId()).orElseThrow(() -> new BAD_REQUEST_EXCEPTION("해당 프로젝트 초대가 유효하지 않습니다."));
 
         projectMemberRepository.save(ProjectMember.builder()
                 .member(member)
@@ -68,7 +68,7 @@ public class InviteAccessService {
     @Transactional
     public void rejectInvite(CustomUserDetails customUserDetails, Long projectInvitedMemberId){
         MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElseThrow(() -> new UserNotFindException("해당 유저가 존재하지 않습니다."));
-        ProjectInvitedMember projectInvitedMember = projectInvitedMemberRepository.findByIdAndMemberId(projectInvitedMemberId,member.getId()).orElseThrow(() -> new BadRequestExeption("해당 프로젝트 초대가 유효하지 않습니다."));
+        ProjectInvitedMember projectInvitedMember = projectInvitedMemberRepository.findByIdAndMemberId(projectInvitedMemberId,member.getId()).orElseThrow(() -> new BAD_REQUEST_EXCEPTION("해당 프로젝트 초대가 유효하지 않습니다."));
         projectInvitedMemberRepository.delete(projectInvitedMember);
     }
 

--- a/sequence_member/src/main/java/sequence/sequence_member/project/dto/ProjectInputDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/dto/ProjectInputDTO.java
@@ -56,5 +56,4 @@ public class ProjectInputDTO {
     private String article;
 
     private String link;
-
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/CommentService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/CommentService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sequence.sequence_member.global.exception.AuthException;
-import sequence.sequence_member.global.exception.BadRequestExeption;
+import sequence.sequence_member.global.exception.BAD_REQUEST_EXCEPTION;
 import sequence.sequence_member.global.exception.CanNotFindResourceException;
 import sequence.sequence_member.global.exception.UserNotFindException;
 import sequence.sequence_member.member.dto.CustomUserDetails;
@@ -61,7 +61,7 @@ public class CommentService {
 
         //수정하려는 댓글의 프로젝트와 요청한 프로젝트가 같은지 확인
          if(!comment.getProject().equals(project)) {
-             throw new BadRequestExeption("해당 프로젝트에 존재하지 않는 댓글입니다.");
+             throw new BAD_REQUEST_EXCEPTION("해당 프로젝트에 존재하지 않는 댓글입니다.");
          }
 
          //수정하려는 댓글의 내용을 변경

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectService.java
@@ -11,7 +11,7 @@ import sequence.sequence_member.global.enums.enums.MeetingOption;
 import sequence.sequence_member.global.enums.enums.Period;
 import sequence.sequence_member.global.enums.enums.Step;
 import sequence.sequence_member.global.exception.AuthException;
-import sequence.sequence_member.global.exception.BadRequestExeption;
+import sequence.sequence_member.global.exception.BAD_REQUEST_EXCEPTION;
 import sequence.sequence_member.global.exception.CanNotFindResourceException;
 import sequence.sequence_member.global.exception.UserNotFindException;
 import sequence.sequence_member.global.utils.DataConvertor;
@@ -148,7 +148,7 @@ public class ProjectService {
         // 삭제된 멤버들은 ProjectMember에서 삭제
         List<MemberEntity> deletedMembers = memberRepository.findByNicknameIn(projectUpdateDTO.getDeletedMembersNicknames());
         if(deletedMembers.contains(writer)){
-            throw new BadRequestExeption("작성자는 멤버에서 삭제할 수 없습니다.");
+            throw new BAD_REQUEST_EXCEPTION("작성자는 멤버에서 삭제할 수 없습니다.");
         }
         projectMemberRepository.deleteByProjectAndMemberIn(project, deletedMembers);
 


### PR DESCRIPTION
팀원평가 생성: 객체 여러개 한 번에 보내도록 수정, linefeedback 삭제(엔티티도 삭제), 응답 불필요 정보 제거
팀원평가조회: 피평가자, 평가자 객체 구분, 유저 정보를 id가 아닌 username으로 수정, 직군(role), 프로필 이미지 정보 추가
팀원평가 상태조회: 상태를 평가전, 평가완료 2개만 쓰도록 수정
아카이브 등록: 팀원평가 등록 시 함께한 멤버 정보가 들어가도록 수정 username, role
아카이브 상세조회: 상세조회 시 함께한 멤버정보 추가
아카이브 수정: 멤버정보는 못바꿈

