### PR TITLE
feat : 프로젝트 조회시 조회수 기능 구현

### DIFF
--- a/sequence_member/build.gradle
+++ b/sequence_member/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 
 	// minio
 	implementation("io.minio:minio:8.5.10")
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis' //redis 의존성
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/sequence_member/src/main/java/sequence/sequence_member/global/config/RedisConfig.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package sequence.sequence_member.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redisHost, redisPort);
+        config.setPassword(redisPassword);  // 비밀번호 설정 추가
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public StringRedisTemplate redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        StringRedisTemplate template = new StringRedisTemplate(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/global/config/SchedulingConfig.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package sequence.sequence_member.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling  // 스케줄링 활성화
+public class SchedulingConfig {
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/global/exception/CanNotFindResourceException.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/exception/CanNotFindResourceException.java
@@ -1,7 +1,9 @@
 package sequence.sequence_member.global.exception;
 
-public class CanNotFindResourceException extends RuntimeException {
+import sequence.sequence_member.global.response.Code;
+
+public class CanNotFindResourceException extends BaseException {
     public CanNotFindResourceException(String message) {
-        super(message);
+        super(Code.CAN_NOT_FIND_RESOURCE,message);
     }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/project/controller/ProjectController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/controller/ProjectController.java
@@ -1,5 +1,6 @@
 package sequence.sequence_member.project.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
@@ -37,14 +38,14 @@ public class ProjectController {
     }
 
     @GetMapping("/{projectId}")
-    public ResponseEntity<ApiResponseData<ProjectOutputDTO>> getProject(@PathVariable("projectId") Long projectId) {
-        return ResponseEntity.ok().body(ApiResponseData.of(Code.SUCCESS.getCode(), "프로젝트 조회 성공", projectService.getProject(projectId)));
+    public ResponseEntity<ApiResponseData<ProjectOutputDTO>> getProject(@PathVariable("projectId") Long projectId, HttpServletRequest request) {
+        return ResponseEntity.ok().body(ApiResponseData.of(Code.SUCCESS.getCode(), "프로젝트 조회 성공", projectService.getProject(projectId, request)));
     }
 
     @PutMapping("/{projectId}")
     public ResponseEntity<ApiResponseData<ProjectOutputDTO>> updateProject(@PathVariable("projectId") Long projectId, @AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody
-                                                                 ProjectUpdateDTO projectUpdateDTO){
-        return ResponseEntity.ok().body(ApiResponseData.of(Code.SUCCESS.getCode(), "프로젝트 수정 성공",projectService.updateProject(projectId, customUserDetails, projectUpdateDTO)));
+                                                                 ProjectUpdateDTO projectUpdateDTO, HttpServletRequest request){
+        return ResponseEntity.ok().body(ApiResponseData.of(Code.SUCCESS.getCode(), "프로젝트 수정 성공",projectService.updateProject(projectId, customUserDetails, projectUpdateDTO,request)));
     }
 
     @DeleteMapping("/{projectId}")

--- a/sequence_member/src/main/java/sequence/sequence_member/project/controller/ProjectController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/controller/ProjectController.java
@@ -18,6 +18,7 @@ import sequence.sequence_member.project.dto.ProjectInputDTO;
 import sequence.sequence_member.project.dto.ProjectOutputDTO;
 import sequence.sequence_member.project.dto.ProjectUpdateDTO;
 import sequence.sequence_member.project.entity.Project;
+import sequence.sequence_member.project.service.ProjectBookmarkService;
 import sequence.sequence_member.project.service.ProjectService;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import java.util.List;
 public class ProjectController {
 
     private final ProjectService projectService;
+    private final ProjectBookmarkService projectBookmarkService;
 
     @PostMapping()
     public ResponseEntity<ApiResponseData<String>> registerProject(@Valid @RequestBody ProjectInputDTO projectInputDTO, @AuthenticationPrincipal
@@ -53,6 +55,14 @@ public class ProjectController {
         projectService.deleteProject(projectId, customUserDetails);
         return ResponseEntity.ok().body(ApiResponseData.success(null, "프로젝트 삭제 성공"));
     }
+
+    //북마크 관련 엔드포인트
+    @PostMapping("/{projectId}/bookmark")
+    public ResponseEntity<ApiResponseData<String>> addProjectBookmark(@PathVariable("projectId") Long projectId, @AuthenticationPrincipal CustomUserDetails customUserDetails){
+        return ResponseEntity.ok().body(ApiResponseData.success(null,projectBookmarkService.addBookmark(customUserDetails, projectId)));
+    }
+
+
 
     @GetMapping("/filter/keyword")
     public ResponseEntity<ApiResponseData<List<ProjectFilterOutputDTO>>> filterKeyword(@RequestParam(name = "category", required = false) Category category,

--- a/sequence_member/src/main/java/sequence/sequence_member/project/controller/ProjectController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/controller/ProjectController.java
@@ -16,6 +16,7 @@ import sequence.sequence_member.member.dto.CustomUserDetails;
 import sequence.sequence_member.project.dto.ProjectFilterOutputDTO;
 import sequence.sequence_member.project.dto.ProjectInputDTO;
 import sequence.sequence_member.project.dto.ProjectOutputDTO;
+import sequence.sequence_member.project.dto.ProjectSummaryInfoDTO;
 import sequence.sequence_member.project.dto.ProjectUpdateDTO;
 import sequence.sequence_member.project.entity.Project;
 import sequence.sequence_member.project.service.ProjectBookmarkService;
@@ -56,10 +57,26 @@ public class ProjectController {
         return ResponseEntity.ok().body(ApiResponseData.success(null, "프로젝트 삭제 성공"));
     }
 
-    //북마크 관련 엔드포인트
+    /**
+     * 북마크 관련 엔드포인트
+     * */
+    // 북마크 등록
     @PostMapping("/{projectId}/bookmark")
     public ResponseEntity<ApiResponseData<String>> addProjectBookmark(@PathVariable("projectId") Long projectId, @AuthenticationPrincipal CustomUserDetails customUserDetails){
         return ResponseEntity.ok().body(ApiResponseData.success(null,projectBookmarkService.addBookmark(customUserDetails, projectId)));
+    }
+    // 북마크 삭제
+    @DeleteMapping("/{projectId}/bookmark")
+    public ResponseEntity<ApiResponseData<String>> removeProjectBookmark(
+            @PathVariable("projectId") Long projectId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok().body(ApiResponseData.success(null, projectBookmarkService.removeBookmark(customUserDetails, projectId)));
+    }
+    // 북마크한 프로젝트 목록 조회
+    @GetMapping("/bookmarks")
+    public ResponseEntity<ApiResponseData<List<ProjectSummaryInfoDTO>>> getBookmarkedProjects(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        return ResponseEntity.ok().body(ApiResponseData.success(projectBookmarkService.getBookmarkedProjects(customUserDetails), "북마크한 프로젝트 목록을 조회하였습니다."));
     }
 
 

--- a/sequence_member/src/main/java/sequence/sequence_member/project/controller/RedisTestController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/controller/RedisTestController.java
@@ -1,0 +1,20 @@
+package sequence.sequence_member.project.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sequence.sequence_member.project.service.RedisTestService;
+
+@RestController
+@RequestMapping("/test")
+@RequiredArgsConstructor
+public class RedisTestController {
+    private final RedisTestService redisTestService;
+
+    @GetMapping("/redis")
+    public String testRedis() {
+        redisTestService.testRedisConnection();
+        return "Redis 테스트 완료!";
+    }
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/project/dto/ProjectOutputDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/dto/ProjectOutputDTO.java
@@ -29,5 +29,5 @@ public class ProjectOutputDTO {
     private String link; // 링크
     private List<ProjectMemberOutputDTO> members; // 초대된 멤버들 nickname, 프로밀이미지, 멤버ID 값을 가지고있음.
     private List<CommentOutputDTO> comments; // 댓글들
-
+    private Long views; //조회수
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/project/dto/ProjectOutputDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/dto/ProjectOutputDTO.java
@@ -29,5 +29,5 @@ public class ProjectOutputDTO {
     private String link; // 링크
     private List<ProjectMemberOutputDTO> members; // 초대된 멤버들 nickname, 프로밀이미지, 멤버ID 값을 가지고있음.
     private List<CommentOutputDTO> comments; // 댓글들
-    private Long views; //조회수
+    private Integer views; //조회수
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/project/dto/ProjectSummaryInfoDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/dto/ProjectSummaryInfoDTO.java
@@ -1,0 +1,16 @@
+package sequence.sequence_member.project.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import sequence.sequence_member.global.enums.enums.Category;
+
+@Getter
+@Builder
+public class ProjectSummaryInfoDTO {
+
+    private Long projectId;
+    private String projectTitle;
+    private String projectName;
+    private String projectWriterNickname;
+    private Category category;
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/project/entity/Project.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/entity/Project.java
@@ -32,7 +32,7 @@ import sequence.sequence_member.project.dto.ProjectInputDTO;
 import sequence.sequence_member.project.dto.ProjectUpdateDTO;
 
 @Entity
-@Getter @Setter
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -129,5 +129,9 @@ public class Project extends BaseTimeEntity {
                 .stream() // Stream<ProjectMemberEntity>
                 .map(projectMemberentity-> projectMemberentity.getMember().getNickname()) // 각 객체의 username 필드 추출
                 .collect(Collectors.toList()); // List<String>으로 변환
+    }
+
+    public void setViews(int views){
+        this.views=views;
     }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/project/entity/Project.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/entity/Project.java
@@ -82,6 +82,9 @@ public class Project extends BaseTimeEntity {
     @Column
     private String link;
 
+    @Column(columnDefinition = "INT DEFAULT 0")
+    private Integer views;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "writer_id")
     private MemberEntity writer;

--- a/sequence_member/src/main/java/sequence/sequence_member/project/entity/ProjectBookmark.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/entity/ProjectBookmark.java
@@ -1,0 +1,39 @@
+package sequence.sequence_member.project.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sequence.sequence_member.global.utils.BaseTimeEntity;
+import sequence.sequence_member.member.entity.MemberEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id","project_id"})) //중복 방지
+public class ProjectBookmark extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY) // 유저와 다대일 관계
+    @JoinColumn(nullable = false)
+    private MemberEntity member;
+
+    @ManyToOne(fetch = FetchType.LAZY) // 프로젝트와 다대일 관계
+    @JoinColumn(nullable = false)
+    private Project project;
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/project/repository/ProjectBookmarkRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/repository/ProjectBookmarkRepository.java
@@ -1,0 +1,12 @@
+package sequence.sequence_member.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import sequence.sequence_member.project.entity.ProjectBookmark;
+
+@Repository
+public interface ProjectBookmarkRepository extends JpaRepository<ProjectBookmark, Long> {
+    boolean existsByMemberIdAndProjectId(Long memberId, Long projectId); // 북마크 존재 여부 확인
+
+    void deleteByMemberIdAndProjectId(Long memberId, Long projectId); // 북마크 삭제
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/project/repository/ProjectBookmarkRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/repository/ProjectBookmarkRepository.java
@@ -1,7 +1,11 @@
 package sequence.sequence_member.project.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import sequence.sequence_member.project.entity.Project;
 import sequence.sequence_member.project.entity.ProjectBookmark;
 
 @Repository
@@ -9,4 +13,8 @@ public interface ProjectBookmarkRepository extends JpaRepository<ProjectBookmark
     boolean existsByMemberIdAndProjectId(Long memberId, Long projectId); // 북마크 존재 여부 확인
 
     void deleteByMemberIdAndProjectId(Long memberId, Long projectId); // 북마크 삭제
+
+    // ✅ 유저가 북마크한 프로젝트 목록 조회
+    @Query("SELECT pb.project FROM ProjectBookmark pb WHERE pb.member.id = :memberId")
+    List<Project> findBookmarkedProjectsByMemberId(@Param("memberId") Long memberId);
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectBookmarkService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectBookmarkService.java
@@ -1,0 +1,55 @@
+package sequence.sequence_member.project.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sequence.sequence_member.global.exception.CanNotFindResourceException;
+import sequence.sequence_member.member.dto.CustomUserDetails;
+import sequence.sequence_member.member.entity.MemberEntity;
+import sequence.sequence_member.member.repository.MemberRepository;
+import sequence.sequence_member.project.entity.Project;
+import sequence.sequence_member.project.entity.ProjectBookmark;
+import sequence.sequence_member.project.repository.ProjectBookmarkRepository;
+import sequence.sequence_member.project.repository.ProjectRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectBookmarkService {
+    private final ProjectBookmarkRepository bookmarkRepository;
+    private final MemberRepository memberRepository;
+    private final ProjectRepository projectRepository;
+
+    @Transactional
+    public String addBookmark(CustomUserDetails customUserDetails, Long projectId) {
+        StringBuilder errMessgage=new StringBuilder(); //만약 null이 아닐경우 오류가 발생한것
+        // 유저와 프로젝트 존재 여부 확인
+        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElse(null);
+        Project project = projectRepository.findById(projectId).orElse(null);
+
+        if(member == null){
+            errMessgage.append("멤버를 찾을 수 없습니다.\n");
+        }
+        if(project == null){
+            errMessgage.append("프로젝트를 찾을 수 없습니다.\n");
+        }
+        if(!errMessgage.isEmpty()){
+            throw new CanNotFindResourceException(errMessgage.toString());
+        }
+
+        // 이미 북마크한 경우 무시
+        if (bookmarkRepository.existsByMemberIdAndProjectId(member.getId(), projectId)) {
+            return "이미 등록한 북마크입니다.";
+        }
+
+        // 북마크 저장
+        ProjectBookmark bookmark = ProjectBookmark.builder()
+                .member(member)
+                .project(project)
+                .build();
+
+        bookmarkRepository.save(bookmark);
+        return "북마크 등록 성공";
+    }
+
+    
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectBookmarkService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectBookmarkService.java
@@ -1,5 +1,7 @@
 package sequence.sequence_member.project.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,6 +9,7 @@ import sequence.sequence_member.global.exception.CanNotFindResourceException;
 import sequence.sequence_member.member.dto.CustomUserDetails;
 import sequence.sequence_member.member.entity.MemberEntity;
 import sequence.sequence_member.member.repository.MemberRepository;
+import sequence.sequence_member.project.dto.ProjectSummaryInfoDTO;
 import sequence.sequence_member.project.entity.Project;
 import sequence.sequence_member.project.entity.ProjectBookmark;
 import sequence.sequence_member.project.repository.ProjectBookmarkRepository;
@@ -51,5 +54,57 @@ public class ProjectBookmarkService {
         return "북마크 등록 성공";
     }
 
-    
+    @Transactional
+    public String removeBookmark(CustomUserDetails customUserDetails, Long projectId) {
+        //todo- 코드 반복됨. 리팩토링 고민
+        StringBuilder errMessgage=new StringBuilder(); //만약 null이 아닐경우 오류가 발생한것
+        // 유저와 프로젝트 존재 여부 확인
+        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElse(null);
+        Project project = projectRepository.findById(projectId).orElse(null);
+
+        if(member == null){
+            errMessgage.append("멤버를 찾을 수 없습니다.\n");
+        }
+        if(project == null){
+            errMessgage.append("프로젝트를 찾을 수 없습니다.\n");
+        }
+        if(!errMessgage.isEmpty()){
+            throw new CanNotFindResourceException(errMessgage.toString());
+        }
+
+        // 북마크가 존재하는지 확인
+        if (!bookmarkRepository.existsByMemberIdAndProjectId(member.getId(), projectId)) {
+            return "해당 프로젝트는 북마크되지 않았습니다.";
+        }
+
+        // 북마크 삭제
+        bookmarkRepository.deleteByMemberIdAndProjectId(member.getId(), projectId);
+        return "북마크 삭제 성공";
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectSummaryInfoDTO> getBookmarkedProjects(CustomUserDetails customUserDetails) {
+        StringBuilder errMessgage=new StringBuilder(); //만약 null이 아닐경우 오류가 발생한것
+        // 유저와 프로젝트 존재 여부 확인
+        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElse(null);
+
+        if(member == null){
+            errMessgage.append("멤버를 찾을 수 없습니다.\n");
+        }
+
+        // 북마크한 프로젝트 목록 조회
+        List<Project> bookmarkedProjects = bookmarkRepository.findBookmarkedProjectsByMemberId(member.getId());
+
+        // DTO 변환 후 반환
+        return bookmarkedProjects.stream()
+                .map(project -> ProjectSummaryInfoDTO.builder()
+                        .projectId(project.getId())
+                        .projectTitle(project.getTitle())
+                        .projectName(project.getProjectName())
+                        .projectWriterNickname(project.getWriter().getNickname())
+                        .category(project.getCategory())
+                        .build()
+                )
+                .collect(Collectors.toList());
+    }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectViewBackupSchedule.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectViewBackupSchedule.java
@@ -14,12 +14,12 @@ import sequence.sequence_member.project.repository.ProjectRepository;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class ProjectViewBackupService {
+public class ProjectViewBackupSchedule {
 
     private final StringRedisTemplate redisTemplate;
     private final ProjectRepository projectRepository;
 
-    @Scheduled(fixedRate = 60000*10) //분*10 = 10분마다 실행(todo - test를 위해 짧은 주리고 동기화중. 추후 수정)
+    @Scheduled(fixedRate = 60000*10*6) //분*10 = 1시간마다 실행(todo - test를 위해 짧은 주리고 동기화중. 추후 수정)
     @Transactional
     public void projectViewBackUpToDB(){
         log.info("Redis 조회수를 DB로 백업 중...");

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectViewBackupService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectViewBackupService.java
@@ -1,0 +1,60 @@
+package sequence.sequence_member.project.service;
+
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sequence.sequence_member.project.entity.Project;
+import sequence.sequence_member.project.repository.ProjectRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProjectViewBackupService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ProjectRepository projectRepository;
+
+    @Scheduled(fixedRate = 60000*10) //분*10 = 10분마다 실행(todo - test를 위해 짧은 주리고 동기화중. 추후 수정)
+    @Transactional
+    public void projectViewBackUpToDB(){
+        log.info("Redis 조회수를 DB로 백업 중...");
+
+        // Redis에서 조회수 키 조회 (viewCount:postId 형태)
+        Set<String> keys = redisTemplate.keys("viewCount:*");
+
+        if (keys == null || keys.isEmpty()) {
+            log.info("저장된 조회수 데이터가 없습니다.");
+            return;
+        }
+
+        for (String key : keys) {
+            try {
+                // key에서 postId 추출
+                Long projectId = Long.parseLong(key.replace("viewCount:", ""));
+
+                // Redis에서 조회수 가져오기
+                String redisViewCountStr = redisTemplate.opsForValue().get(key);
+                int redisViewCount = (redisViewCountStr != null) ? Integer.parseInt(redisViewCountStr) : 0;
+
+                // DB 업데이트
+                Optional<Project> project = projectRepository.findById(projectId);
+
+                //만약 해당 프로젝트가 존재하지 않다면 무시
+                if(project.isEmpty()) {
+                    log.error("redis에 존재하지 않는 projectId가 존재합니다 : {}", projectId);
+                    continue;
+                }
+                project.get().setViews(redisViewCount);
+                projectRepository.save(project.get());
+                log.info("게시글 [{}] 조회수 업데이트 완료! 총 조회수: {}", projectId, redisViewCount);
+            } catch (Exception e) {
+                log.error("조회수 동기화 중 오류 발생: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectViewService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectViewService.java
@@ -1,0 +1,78 @@
+package sequence.sequence_member.project.service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import sequence.sequence_member.global.annotation.MethodDescription;
+import sequence.sequence_member.project.entity.Project;
+import sequence.sequence_member.project.repository.ProjectRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectViewService {
+    private final ProjectRepository projectRepository;
+    private final StringRedisTemplate redisTemplate;
+    private static final long VIEW_EXPIRATION_TIME = 60 * 60; // 1시간 유지
+
+    @MethodDescription(description = "Redis에서 조회수를 가져오는 로직")
+    public int getViewsFromRedis(HttpServletRequest request, Long postId){
+
+        // IP + User-Agent로 조회이력을 확인할 고유 Value값 생성.
+        String clientId = getClientIP(request)+getUserAgent(request).hashCode();
+
+        //조회 이력을 확인하기 위한 key. redis에 저장된 key값. viewed3:Set<ClientId> 가 key:value형태로 저장됨.
+        String key = "viewed:" + postId;
+
+        //조회수 확인 및 증가를 위한 key
+        String viewedKey = "viewCount:" + postId;
+
+        // 조회수가 없으면 0으로 초기화
+        redisTemplate.opsForValue().setIfAbsent(viewedKey, "0");
+
+        // clientId를 활용하여 조회 이력이 없을경우. 조회수 증가 및 확인 처리.
+        if(!isAlreadyViewed(postId,clientId)){
+
+            // 조회수 증가
+            redisTemplate.opsForValue().increment(viewedKey);
+
+            //조회 기록 저장
+            redisTemplate.opsForSet().add(key, clientId);
+            redisTemplate.expire(key, Duration.ofSeconds(VIEW_EXPIRATION_TIME)); // 1시간 후 자동 삭제
+        }
+
+        return Integer.parseInt(Objects.requireNonNullElse(redisTemplate.opsForValue().get(viewedKey),"0"));
+    }
+
+
+    @MethodDescription(description = "이미 조회한 글인지 확인")
+    private boolean isAlreadyViewed(Long postId, String clientId){
+        String key = "viewed:" + postId;
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, clientId));
+    }
+
+    @MethodDescription(description = "user의 ip 조회.")
+    private String getClientIP(HttpServletRequest request){
+        String ip = request.getHeader("X-Forward-For");
+
+        if(ip == null || ip.isBlank()){
+            ip = request.getRemoteAddr();
+        }
+
+        return ip;
+    }
+
+    @MethodDescription(description = "User의 user-agent정보 조회. 없으면 빈문자열")
+    private String getUserAgent(HttpServletRequest request){
+        String userAgent = request.getHeader("User-Agent");
+
+        if (userAgent == null) {
+            userAgent="";
+        }
+
+        return userAgent;
+    }
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/RedisTestService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/RedisTestService.java
@@ -1,0 +1,17 @@
+package sequence.sequence_member.project.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisTestService {
+    private final StringRedisTemplate redisTemplate;
+
+    public void testRedisConnection() {
+        redisTemplate.opsForValue().set("testKey", "Hello, Redis!");
+        String value = redisTemplate.opsForValue().get("testKey");
+        System.out.println("Redis에서 가져온 값: " + value);
+    }
+}

--- a/sequence_member/src/main/resources/application.yml
+++ b/sequence_member/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/sequence_member/src/main/resources/application.yml
+++ b/sequence_member/src/main/resources/application.yml
@@ -30,6 +30,12 @@ spring:
   jwt:
     secret: ${JWT_SECRET}
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+      timeout: 6000ms
 minio:
   endpoint: ${MINIO_ENDPOINT}
   accessKey: ${MINIO_ACCESS_KEY}


### PR DESCRIPTION
프로젝트 조회시 조회수를 함께 return하도록 기능을 구현하였습니다.
# 이슈 중복 체크 검증
이슈를 중복하기 위한 기술에는 여러가지가가 존재하였습니다.

- 쿠키 : 가장 널리사용. 쿠키 날리면 조회수 계속 증가시킬수있음.
- 세션 : 브라우저 종료하고 세션 끊으면 조회수 계속 증가시킬수있음. 쿠키에 세션정보를 담아서 관리하는데 쿠키를 삭제하면 마찬가지로 조회수 계속 증가 가능.
- IP : 같은 지역(IP가 동일한 환경) 에서는 여러 유저가 방문해도 조회수 증가 안함.
- MAC : MAC주소를 활용하여 중복 체크. 기기 바꾸면 조회수 증가함. MAC주소를 가져오는것은 보안때문에 불가능합니다.
이외에도 여러가지 방법이 있었습니다.

# 선택한 방법
UserAgent + IP 주소로 검증.
1. 학교와 같은 공공 네트워크에서는 IP가 같은 경우가 많습니다. 저희 서비스 특성상 학교에서 많이 사용할텐데 IP만을 가지고 진행한다면 조회수를 제대로 카운트 하지 못하는 문제가 있을 것입니다.
2. UserAgent(사용자 소프트웨어의 식별 정보를 담고 있는 request header의 한 종류 - 브라우저에서 저장) 을 함께 활용하여 해당 문제를 해결하였습니다.

# 처리 과정
1. client가 게시글 조회 요청 
2. Redis에서 해당글 조회 이력 확인 ( IP + UserAgent정보 활용)
3-1. 없다면 조회수를 1증가 시키고 조회수를 return
3-2. 조회한이력이 있다면 증가 시키지 않고 return

또한 스케줄링을 활용하여 주기적으로 DB에 조회수를 업데이트합니다. (백업 용도)
만약 Redis에서 데이터를 불러오는 도중 문제가 발생한다면 DB에 저장되어있는 조회수를 가져옵니다.
