### PR TITLE
[fix]: 포트폴리오 파일 입력 처리 오류 해결 및 수정

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/global/utils/DataCreateService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/utils/DataCreateService.java
@@ -50,7 +50,7 @@ public class DataCreateService {
                 member.setPhone(faker.numerify("010-####-####"));  // 한국식 번호
                 member.setEmail(batchNumber + "_" + i + "_" + faker.internet().emailAddress());
                 member.setIntroduction(faker.lorem().sentence());
-                member.setPortfolio(faker.internet().url());
+//                member.setPortfolios(faker.internet().url());
                 member.setNickname(batchNumber + "_" + i + "_" + faker.funnyName().name());
                 member.setSchoolName(faker.educator().university());
                 member.setProfileImg(faker.internet().avatar());

--- a/sequence_member/src/main/java/sequence/sequence_member/member/entity/PortfolioEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/entity/PortfolioEntity.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Setter
+@Getter @Setter
 @Table(name = "portfolio")
 public class PortfolioEntity {
 

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/PortfolioRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/PortfolioRepository.java
@@ -2,8 +2,10 @@ package sequence.sequence_member.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import sequence.sequence_member.member.entity.MemberEntity;
 import sequence.sequence_member.member.entity.PortfolioEntity;
 
 @Repository
 public interface PortfolioRepository extends JpaRepository<PortfolioEntity, Long> {
+    void deleteByMember(MemberEntity member);
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/controller/MyPageController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package sequence.sequence_member.mypage.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
@@ -9,11 +10,15 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 import sequence.sequence_member.global.response.ApiResponseData;
 import sequence.sequence_member.global.response.Code;
 import sequence.sequence_member.mypage.dto.MyPageRequestDTO;
 import sequence.sequence_member.mypage.dto.MyPageResponseDTO;
 import sequence.sequence_member.mypage.service.MyPageService;
+
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -41,13 +46,17 @@ public class MyPageController {
         }
     }
 
-    @PutMapping("/api/mypage")
-    public ResponseEntity<ApiResponseData<String>> updateMyProfile(@RequestBody MyPageRequestDTO myPageDTO) {
+    @PutMapping(value = "/api/mypage", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<ApiResponseData<String>> updateMyProfile(
+            @RequestPart(name = "myPageDTO") MyPageRequestDTO myPageDTO,
+            @RequestPart(name = "authImgFile", required = false) MultipartFile authImgFile,
+            @RequestPart(name = "portfolios", required = false) List<MultipartFile> portfolios
+    ) {
 
         String username = SecurityContextHolder.getContext().getAuthentication().getName();
 
         try {
-            myPageService.updateMyProfile(myPageDTO, username);
+            myPageService.updateMyProfile(myPageDTO, username, authImgFile, portfolios);
             return ResponseEntity.ok(ApiResponseData.success("마이페이지 수정이 완료되었습니다."));
         } catch (Exception e) {
             return ResponseEntity.status(Code.CAN_NOT_FIND_RESOURCE.getStatus())

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageMapper.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageMapper.java
@@ -1,12 +1,10 @@
 package sequence.sequence_member.mypage.dto;
 
-import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 import sequence.sequence_member.archive.dto.ArchivePageResponseDTO;
 import sequence.sequence_member.archive.entity.Archive;
 import sequence.sequence_member.archive.service.ArchiveService;
-import sequence.sequence_member.global.utils.DataConvertor;
 import sequence.sequence_member.member.entity.MemberEntity;
 
 import java.util.List;
@@ -37,7 +35,6 @@ public class MyPageMapper {
                 member.getAddress(),
                 member.getPhone(),
                 member.getIntroduction(),
-                DataConvertor.stringToList(member.getPortfolio()),
                 member.getNickname(),
                 member.getEducation().getSchoolName(),
                 member.getEducation().getMajor(),
@@ -48,6 +45,14 @@ public class MyPageMapper {
                 member.getEducation().getSkillCategory(),
                 member.getEducation().getDesiredJob()
         );
+
+        // PortfolioDTO 리스트 생성
+        List<MyPageResponseDTO.PortfolioDTO> portfolios = member.getPortfolios().stream()
+                .map(portfolio -> new MyPageResponseDTO.PortfolioDTO(
+                        portfolio.getPortfolioUrl()
+                ))
+                .collect(Collectors.toList());
+        dto.setPortfolios(portfolios);
 
         // AwardDTO 리스트 생성
         List<MyPageResponseDTO.AwardDTO> awards = member.getAwards().stream()

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageRequestDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageRequestDTO.java
@@ -39,7 +39,6 @@ public class MyPageRequestDTO {
     private String phone;
 
     private String introduction;
-    private List<String> portfolio; // todo - minio에 저장할 수 있도록 추가해야 함
 
     @NotBlank(message = "닉네임은 필수 입력 값입니다.")
     private String nickname;

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageResponseDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageResponseDTO.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
-import sequence.sequence_member.archive.dto.ArchiveOutputDTO;
 import sequence.sequence_member.archive.dto.ArchivePageResponseDTO;
 import sequence.sequence_member.global.enums.enums.AwardType;
 import sequence.sequence_member.global.enums.enums.Degree;
@@ -15,7 +14,6 @@ import sequence.sequence_member.global.enums.enums.Skill;
 import sequence.sequence_member.member.entity.MemberEntity.Gender;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 
@@ -42,7 +40,6 @@ public class MyPageResponseDTO {
     private String phone;
 
     private String introduction;
-    private List<String> portfolio; // todo - minio에 저장할 수 있도록 추가해야 함
 
     @NotBlank(message = "닉네임은 필수 입력 값입니다.")
     private String nickname;
@@ -64,6 +61,7 @@ public class MyPageResponseDTO {
     @NotNull(message = "학위는 필수 입력 값입니다.")
     private Degree degree;
 
+    private List<PortfolioDTO> portfolios;
     private List<Skill> skillCategory;
     private List<ProjectRole> desiredJob;
 
@@ -75,7 +73,7 @@ public class MyPageResponseDTO {
 
     public MyPageResponseDTO(
             String username, String name, Date birth, Gender gender, String address,
-            String phone, String introduction, List<String> portfolio, String nickname,
+            String phone, String introduction, String nickname,
             String schoolName, String major, String grade, Date entranceDate, Date graduationDate,
             Degree degree, List<Skill> skillCategory, List<ProjectRole> desiredJob) {
         this.username = username;
@@ -85,7 +83,6 @@ public class MyPageResponseDTO {
         this.address = address;
         this.phone = phone;
         this.introduction = introduction;
-        this.portfolio = portfolio;
         this.nickname = nickname;
         this.schoolName = schoolName;
         this.major = major;
@@ -142,6 +139,15 @@ public class MyPageResponseDTO {
             this.startDate = startDate;
             this.endDate = endDate;
             this.experienceDescription = experienceDescription;
+        }
+    }
+
+    @Data
+    public static class PortfolioDTO {
+        private final String portfolioUrl;
+
+        public PortfolioDTO(String portfolioUrl) {
+            this.portfolioUrl = portfolioUrl;
         }
     }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import org.springframework.web.multipart.MultipartFile;
 import sequence.sequence_member.archive.entity.Archive;
 import sequence.sequence_member.archive.repository.ArchiveRepository;
 import sequence.sequence_member.member.entity.MemberEntity;
@@ -17,6 +18,7 @@ import sequence.sequence_member.mypage.dto.MyPageMapper;
 import sequence.sequence_member.mypage.dto.MyPageRequestDTO;
 import sequence.sequence_member.mypage.dto.MyPageResponseDTO;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -57,7 +59,10 @@ public class MyPageService {
      * @throws EntityNotFoundException 사용자를 찾을 수 없는 경우 발생
      */
     @Transactional
-    public void updateMyProfile(MyPageRequestDTO myPageDTO, String username) {
+    public void updateMyProfile(
+            MyPageRequestDTO myPageDTO, String username,
+            MultipartFile authImgFile, List<MultipartFile> portfolios
+    ) {
         MemberEntity member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
       
@@ -65,7 +70,7 @@ public class MyPageService {
             throw new IllegalArgumentException("아이디는 변경할 수 없습니다.");
         }
 
-        myPageUpdateService.updateProfile(member, myPageDTO);
+        myPageUpdateService.updateProfile(member, myPageDTO, authImgFile, portfolios);
     }
 
     /**


### PR DESCRIPTION
[목적]: 마이페이지에서 포트폴리오를 파일 형식으로 입력받는 과정에서 발생한 오류를 해결하고, 포트폴리오 파일을 처리할 수 있도록 수정하기 위해서.

[목표]:
- 마이페이지에서 포트폴리오를 파일 형식으로 입력받을 수 있게 수정.
- 포트폴리오 파일 관련 오류 해결 완료.
- DataCreateService에서 더미 데이터 추가 시 53번째 줄 수정 필요 (현재 주석 처리됨).

[달성도]:
- 마이페이지에서 포트폴리오를 파일 형식으로 처리하는 기능 정상화.
- 관련 오류 해결 및 마이페이지 수정 완료.

[기타]: 더미 데이터 생성 시 DataCreateService의 53번째 줄 수정 필요. 해당 부분은 주석 처리하여 임시 해결됨.