### PR TITLE
아카이브 수정, 삭제 시 request에서 writer삭제, 리스트 조회 시 필요한 정보만 반환하도록 간소화

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/archive/controller/ArchiveCommentController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/controller/ArchiveCommentController.java
@@ -61,8 +61,13 @@ public class ArchiveCommentController {
             throw new BAD_REQUEST_EXCEPTION("로그인이 필요합니다.");
         }
         
-        boolean success = commentService.updateComment(archiveId, commentId, requestDto.getWriter(), requestDto);
-        
+        boolean success = commentService.updateComment(
+            archiveId, 
+            commentId, 
+            userDetails.getUsername(),
+            requestDto
+        );
+
         if (!success) {
             throw new CanNotFindResourceException("아카이브 또는 댓글을 찾을 수 없거나 이미 삭제된 댓글입니다.");
         }
@@ -79,14 +84,17 @@ public class ArchiveCommentController {
     public ResponseEntity<ApiResponseData<Void>> deleteComment(
             @PathVariable Long archiveId,
             @PathVariable Long commentId,
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody CommentUpdateRequestDTO requestDto) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         
         if (userDetails == null) {
             throw new BAD_REQUEST_EXCEPTION("로그인이 필요합니다.");
         }
         
-        boolean success = commentService.deleteComment(archiveId, commentId, requestDto.getWriter());
+        boolean success = commentService.deleteComment(
+            archiveId, 
+            commentId, 
+            userDetails.getUsername()
+        );
         
         if (!success) {
             throw new CanNotFindResourceException("아카이브 또는 댓글을 찾을 수 없거나 이미 삭제된 댓글입니다.");

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/controller/ArchiveController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/controller/ArchiveController.java
@@ -21,6 +21,7 @@ import sequence.sequence_member.global.response.ApiResponseData;
 import sequence.sequence_member.global.response.Code;
 import sequence.sequence_member.member.dto.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Value;  
+import sequence.sequence_member.archive.dto.ArchiveListDTO;
 
 import java.util.List;
 
@@ -134,14 +135,14 @@ public class ArchiveController {
 
     // 전체 리스트 조회
     @GetMapping("/projects")
-    public ResponseEntity<ApiResponseData<ArchivePageResponseDTO>> getArchiveList(
+    public ResponseEntity<ApiResponseData<ArchiveListDTO>> getArchiveList(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "LATEST") SortType sortType) {
         
         String username = (userDetails != null) ? userDetails.getUsername() : null;
         
-        ArchivePageResponseDTO response = archiveService.getAllArchives(page, sortType, username);
+        ArchiveListDTO response = archiveService.getAllArchives(page, sortType, username);
         
         if (response.getArchives().isEmpty()) {
             throw new CanNotFindResourceException("아카이브가 없습니다.");
@@ -156,7 +157,7 @@ public class ArchiveController {
 
     // 검색
     @GetMapping("/projects/search")
-    public ResponseEntity<ApiResponseData<ArchivePageResponseDTO>> searchArchives(
+    public ResponseEntity<ApiResponseData<ArchiveListDTO>> searchArchives(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(required = false) Category category,
@@ -165,7 +166,7 @@ public class ArchiveController {
         
         String username = (userDetails != null) ? userDetails.getUsername() : null;
         
-        ArchivePageResponseDTO response = archiveService.searchArchives(category, keyword, page, sortType, username);
+        ArchiveListDTO response = archiveService.searchArchives(category, keyword, page, sortType, username);
         
         if (response.getArchives().isEmpty()) {
             throw new CanNotFindResourceException("아카이브가 없습니다.");

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveListDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/dto/ArchiveListDTO.java
@@ -1,0 +1,25 @@
+package sequence.sequence_member.archive.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ArchiveListDTO {
+    private List<ArchiveSimpleDTO> archives;
+    private int totalPages;
+    private long totalElements;  // 전체 아카이브 수
+
+    @Getter
+    @Builder
+    public static class ArchiveSimpleDTO {
+        private Long id;
+        private String title;
+        private String writerNickname;
+        private String thumbnail;
+        private int commentCount;
+        private LocalDateTime createdDateTime;
+    }
+} 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/dto/CommentUpdateRequestDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/dto/CommentUpdateRequestDTO.java
@@ -16,7 +16,4 @@ public class CommentUpdateRequestDTO {
     @NotBlank(message = "댓글 내용을 입력해주세요.")
     @Size(max = 500, message = "댓글은 500자 이하로 입력해주세요.")
     private String content;
-    
-    @NotBlank(message = "작성자를 입력해주세요.")
-    private String writer;
 } 

--- a/sequence_member/src/main/java/sequence/sequence_member/member/dto/CustomUserDetails.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/dto/CustomUserDetails.java
@@ -10,9 +10,11 @@ import java.util.Collection;
 public class CustomUserDetails implements UserDetails {
 
     private final MemberEntity memberEntity;
+    private final String nickname;
 
     public CustomUserDetails(MemberEntity memberEntity){
         this.memberEntity = memberEntity;
+        this.nickname = memberEntity.getNickname();
     }
 
     @Override
@@ -30,7 +32,9 @@ public class CustomUserDetails implements UserDetails {
         return memberEntity.getUsername();
     }
 
-    public String getNickname() { return memberEntity.getNickname(); }
+    public String getNickname() {
+        return this.nickname;
+    }
 
     @Override
     public boolean isAccountNonExpired() {


### PR DESCRIPTION
1. 아카이브 리스트 데이터 간소화 완료
아카이브 총 갯수
총 페이지 수
각 아카이브: title, 댓글 수, 작성자, 작성날짜, 썸네일

2. 아카이브 수정 삭제 시 request에서 writer 받지 않고 토큰으로 username -> nickname 찾아 검증 후 수정 삭제로 수정
수정 시에는 comment만 받고 삭제 시에는 아무것도 안받음