### PR TITLE
feat: 게시글 신고 기능 추가

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/report/controller/ReportController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/controller/ReportController.java
@@ -35,30 +35,13 @@ public class ReportController {
         return ResponseEntity.ok().body(ApiResponseData.of(Code.SUCCESS.getCode(), "신고내역 조회가 성공했습니다.",reportService.searchReport(nickname)));
     }
 
-    // 신고 대상 정보 조회
-    @GetMapping("/target/user/{nickname}")
-    public ResponseEntity<ApiResponseData<ReportTargetDTO>> getReportTarget(@PathVariable("nickname") String nickname) {
-        return ResponseEntity.ok().body(ApiResponseData.success(reportService.getReportTarget(nickname, null, null), "신고 대상 정보 조회 성공"));
+    @GetMapping("/target/{targetType}/{targetId}")
+    public ResponseEntity<ApiResponseData<ReportTargetDTO>> getReportTarget(
+            @PathVariable("targetType") String targetType,
+            @PathVariable("targetId") Long targetId
+    ) {
+        ReportTargetDTO targetDTO = reportService.getDynamicReportTarget(targetType.toUpperCase(), targetId);
+        return ResponseEntity.ok().body(ApiResponseData.success(targetDTO, "신고 대상 정보 조회 성공"));
     }
 
-    // 신고 대상 댓글 조회
-    @GetMapping("/target/comment/{commentId}")
-    public ResponseEntity<ApiResponseData<ReportTargetDTO>> getReportCommentTarget(@PathVariable("commentId") Long commentId) {
-
-        return ResponseEntity.ok().body(ApiResponseData.success(reportService.getReportCommentTarget(commentId), "신고 대상 정보 조회 성공"));
-    }
-
-    // 신고 대상 프로젝트 조회
-    @GetMapping("/target/project/{projectId}")
-    public ResponseEntity<ApiResponseData<ReportTargetDTO>> getReportProjectTarget(@PathVariable("projectId") Long projectId) {
-
-        return ResponseEntity.ok().body(ApiResponseData.success(reportService.getReportProjectTarget(projectId), "신고 대상 정보 조회 성공"));
-    }
-
-    // 신고 대상 프로젝트 조회
-    @GetMapping("/target/archive/{archiveId}")
-    public ResponseEntity<ApiResponseData<ReportTargetDTO>> getReportArchiveTarget(@PathVariable("archiveId") Long archiveId) {
-
-        return ResponseEntity.ok().body(ApiResponseData.success(reportService.getReportArchiveTarget(archiveId), "신고 대상 정보 조회 성공"));
-    }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/report/controller/ReportController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/controller/ReportController.java
@@ -36,9 +36,29 @@ public class ReportController {
     }
 
     // 신고 대상 정보 조회
-    @GetMapping("/target/{nickname}")
+    @GetMapping("/target/user/{nickname}")
     public ResponseEntity<ApiResponseData<ReportTargetDTO>> getReportTarget(@PathVariable("nickname") String nickname) {
-        return ResponseEntity.ok().body(ApiResponseData.success(reportService.getReportTarget(nickname), "신고 대상 정보 조회 성공"));
+        return ResponseEntity.ok().body(ApiResponseData.success(reportService.getReportTarget(nickname, null, null), "신고 대상 정보 조회 성공"));
     }
 
+    // 신고 대상 댓글 조회
+    @GetMapping("/target/comment/{commentId}")
+    public ResponseEntity<ApiResponseData<ReportTargetDTO>> getReportCommentTarget(@PathVariable("commentId") Long commentId) {
+
+        return ResponseEntity.ok().body(ApiResponseData.success(reportService.getReportCommentTarget(commentId), "신고 대상 정보 조회 성공"));
+    }
+
+    // 신고 대상 프로젝트 조회
+    @GetMapping("/target/project/{projectId}")
+    public ResponseEntity<ApiResponseData<ReportTargetDTO>> getReportProjectTarget(@PathVariable("projectId") Long projectId) {
+
+        return ResponseEntity.ok().body(ApiResponseData.success(reportService.getReportProjectTarget(projectId), "신고 대상 정보 조회 성공"));
+    }
+
+    // 신고 대상 프로젝트 조회
+    @GetMapping("/target/archive/{archiveId}")
+    public ResponseEntity<ApiResponseData<ReportTargetDTO>> getReportArchiveTarget(@PathVariable("archiveId") Long archiveId) {
+
+        return ResponseEntity.ok().body(ApiResponseData.success(reportService.getReportArchiveTarget(archiveId), "신고 대상 정보 조회 성공"));
+    }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportRequestDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportRequestDTO.java
@@ -1,9 +1,6 @@
 package sequence.sequence_member.report.dto;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Data;
-import lombok.Getter;
 import sequence.sequence_member.report.entity.ReportEntity;
 
 import java.util.List;
@@ -15,6 +12,6 @@ public class ReportRequestDTO {
     private List<ReportEntity.ReportType> reportType;
     private ReportEntity.ReportTarget reportTarget;
     private String reportContent;
-    private Long postId;
+    private Long targetId;
 }
 

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportRequestDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportRequestDTO.java
@@ -12,11 +12,10 @@ import java.util.List;
 public class ReportRequestDTO {
 
     private String nickname;
-    private List<ReportEntity.ReportType> reportType;
     private String reporter;
-
-    @NotBlank(message = "아이디는 필수 입력 값입니다.")
-    @Size(min= 4, max= 10, message = "아이디는 최소 4자 이상 최대 10자 이하입니다.")
+    private List<ReportEntity.ReportType> reportType;
+    private List<ReportEntity.ReportTarget> reportTarget;
+    private Long postId;
     private String reportContent;
 
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportRequestDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportRequestDTO.java
@@ -10,12 +10,11 @@ import java.util.List;
 
 @Data
 public class ReportRequestDTO {
-
     private String nickname;
     private String reporter;
     private List<ReportEntity.ReportType> reportType;
-    private List<ReportEntity.ReportTarget> reportTarget;
-    private Long postId;
+    private ReportEntity.ReportTarget reportTarget;
     private String reportContent;
-
+    private Long postId;
 }
+

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportResponseDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportResponseDTO.java
@@ -16,7 +16,8 @@ public class ReportResponseDTO {
     private String nickname;
     private String reporter;
     private List<String> reportTypes;
-    private List<String> reportTarget;
+    private ReportEntity.ReportTarget reportTarget;
     private Long postId;
     private String reportContent;
 }
+

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportResponseDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportResponseDTO.java
@@ -15,6 +15,8 @@ public class ReportResponseDTO {
     private Long id;
     private String nickname;
     private String reporter;
-    private List<String> reportTypes;  // 한글 설명 리스트
+    private List<String> reportTypes;
+    private List<String> reportTarget;
+    private Long postId;
     private String reportContent;
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportResponseDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportResponseDTO.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import sequence.sequence_member.report.entity.ReportEntity;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Data
 @Builder
@@ -17,7 +16,7 @@ public class ReportResponseDTO {
     private String reporter;
     private List<String> reportTypes;
     private ReportEntity.ReportTarget reportTarget;
-    private Long postId;
+    private Long targetId;
     private String reportContent;
 }
 

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportTargetDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportTargetDTO.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 import sequence.sequence_member.global.enums.enums.Degree;
 import sequence.sequence_member.report.entity.ReportEntity;
 
-import java.util.List;
-
 @Getter
 @AllArgsConstructor
 public class ReportTargetDTO {
@@ -16,5 +14,5 @@ public class ReportTargetDTO {
     private String grade;
     private Degree degree;
     private ReportEntity.ReportTarget reportTarget;
-    private Long postId;
+    private Long targetId;
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportTargetDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportTargetDTO.java
@@ -3,6 +3,7 @@ package sequence.sequence_member.report.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import sequence.sequence_member.global.enums.enums.Degree;
+import sequence.sequence_member.report.entity.ReportEntity;
 
 import java.util.List;
 
@@ -14,6 +15,6 @@ public class ReportTargetDTO {
     private String major;
     private String grade;
     private Degree degree;
-    private List<String> reportTarget;
+    private ReportEntity.ReportTarget reportTarget;
     private Long postId;
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportTargetDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/dto/ReportTargetDTO.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import sequence.sequence_member.global.enums.enums.Degree;
 
+import java.util.List;
+
 @Getter
 @AllArgsConstructor
 public class ReportTargetDTO {
@@ -12,4 +14,6 @@ public class ReportTargetDTO {
     private String major;
     private String grade;
     private Degree degree;
+    private List<String> reportTarget;
+    private Long postId;
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/report/entity/ReportEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/entity/ReportEntity.java
@@ -31,7 +31,7 @@ public class ReportEntity extends BaseTimeEntity {
     @Column(name = "report_target")
     private ReportTarget reportTarget;
 
-    private Long postId;
+    private Long ta rgetId;
 
     @Column(columnDefinition = "TEXT", length = 500)
     private String reportContent;

--- a/sequence_member/src/main/java/sequence/sequence_member/report/entity/ReportEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/entity/ReportEntity.java
@@ -27,11 +27,9 @@ public class ReportEntity extends BaseTimeEntity {
     @Column(name = "report_type")
     private List<ReportType> reportTypes;
 
-    @ElementCollection(fetch = FetchType.LAZY)
     @Enumerated(EnumType.STRING)
-    @CollectionTable(name = "report_targets", joinColumns = @JoinColumn(name = "report_id"))
     @Column(name = "report_target")
-    private List<ReportType> reportTarget;
+    private ReportTarget reportTarget;
 
     private Long postId;
 
@@ -74,11 +72,18 @@ public class ReportEntity extends BaseTimeEntity {
             this.description = description;
         }
 
-        public static ReportType fromDescription(String description) {
-            return Arrays.stream(ReportType.values())
-                    .filter(type -> type.getDescription().equals(description))
+        public static ReportTarget from(String name) {
+            return Arrays.stream(values())
+                    .filter(t -> t.name().equalsIgnoreCase(name))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("잘못된 신고 대상입니다: " + description));
+                    .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 대상: " + name));
+        }
+
+        public static ReportTarget fromDescription(String desc) {
+            return Arrays.stream(values())
+                    .filter(t -> t.description.equals(desc))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("잘못된 설명: " + desc));
         }
     }
 

--- a/sequence_member/src/main/java/sequence/sequence_member/report/entity/ReportEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/entity/ReportEntity.java
@@ -31,7 +31,7 @@ public class ReportEntity extends BaseTimeEntity {
     @Column(name = "report_target")
     private ReportTarget reportTarget;
 
-    private Long ta rgetId;
+    private Long targetId;
 
     @Column(columnDefinition = "TEXT", length = 500)
     private String reportContent;

--- a/sequence_member/src/main/java/sequence/sequence_member/report/entity/ReportEntity.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/entity/ReportEntity.java
@@ -27,6 +27,13 @@ public class ReportEntity extends BaseTimeEntity {
     @Column(name = "report_type")
     private List<ReportType> reportTypes;
 
+    @ElementCollection(fetch = FetchType.LAZY)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "report_targets", joinColumns = @JoinColumn(name = "report_id"))
+    @Column(name = "report_target")
+    private List<ReportType> reportTarget;
+
+    private Long postId;
 
     @Column(columnDefinition = "TEXT", length = 500)
     private String reportContent;
@@ -54,5 +61,25 @@ public class ReportEntity extends BaseTimeEntity {
         }
     }
 
+    @Getter
+    public enum ReportTarget {
+        USER("유저"),
+        COMMENT("댓글"),
+        PROJECT("프로젝트"),
+        ARCHIVE("아카이브");
+
+        private final String description;
+
+        ReportTarget(String description) {
+            this.description = description;
+        }
+
+        public static ReportType fromDescription(String description) {
+            return Arrays.stream(ReportType.values())
+                    .filter(type -> type.getDescription().equals(description))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("잘못된 신고 대상입니다: " + description));
+        }
+    }
 
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/report/service/ReportService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/service/ReportService.java
@@ -82,7 +82,7 @@ public class ReportService {
                 .reportTypes(reportRequestDTO.getReportType())
                 .reportTarget(reportRequestDTO.getReportTarget())
                 .reportContent(reportRequestDTO.getReportContent())
-                .postId(reportRequestDTO.getPostId())
+                .targetId(reportRequestDTO.getTargetId())
                 .build();
 
         reportRepository.save(reportEntity);
@@ -103,7 +103,7 @@ public class ReportService {
                     .reportContent(reportEntity.getReportContent())
                     .reporter(reportEntity.getReporter())
                     .reportTarget(reportEntity.getReportTarget())
-                    .postId(reportEntity.getPostId())
+                    .targetId(reportEntity.getTargetId())
                     .build());
         }
 
@@ -111,12 +111,11 @@ public class ReportService {
     }
 
 
-    public ReportTargetDTO getReportTarget(Long userId, Long postId, String targetType) {
+    public ReportTargetDTO getReportTarget(Long userId, Long targetId, String targetType) {
         MemberEntity member = memberRepository.findById(userId)
                 .orElseThrow(() -> new CanNotFindResourceException("해당 유저가 존재하지 않습니다."));
 
-        Long targetId = postId;
-        if(postId == null){
+        if(targetId == null){
             targetId = member.getId();
         };
 


### PR DESCRIPTION
개요
- PROJECT, COMMENT, ARCHIVE에 대한 신고도 가능하도록 기능 확장
- 이에 따라 신고 요청 시 대상의 형식을 나타내는 reportTarget, ID를 나타내는 targetId를 추가

변경 사항
- 신고 대상 조회 API의 주소를 /target/{targetType}/{targetId}로 변경
- targetType은 USER, PROJECT, COMMENT, ARCHIVE 중 하나 (user, project, comment, archive)
