### PR TITLE
[refactor]: MyPageResponseDTO의 PortfolioDTO 구조 변경

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/archive/repository/ArchiveRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/repository/ArchiveRepository.java
@@ -58,4 +58,6 @@ public interface ArchiveRepository extends JpaRepository<Archive, Long> {
     // 특정 멤버의 아카이브 중 상태가 평가완료인 것만 조회
     List<Archive> findTop5ByArchiveMembers_Member_IdAndStatusOrderByCreatedDateTimeDesc(
         Long memberId, Status status);
+
+    Page<Archive> findByWriter(MemberEntity writer, Pageable pageable);
 } 

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sequence.sequence_member.archive.dto.ArchiveOutputDTO;
-import sequence.sequence_member.archive.dto.ArchivePageResponseDTO;
 import sequence.sequence_member.archive.dto.ArchiveRegisterInputDTO;
 import sequence.sequence_member.archive.dto.ArchiveUpdateDTO;
 import sequence.sequence_member.archive.dto.ArchiveMemberDTO;
@@ -35,7 +34,7 @@ import sequence.sequence_member.archive.entity.ArchiveComment;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.beans.factory.annotation.Value;
-import sequence.sequence_member.global.minio.service.MinioService;
+
 import java.util.Optional;
 import sequence.sequence_member.archive.repository.TeamEvaluationRepository;
 import sequence.sequence_member.global.exception.BAD_REQUEST_EXCEPTION;
@@ -356,19 +355,6 @@ public class ArchiveService {
                 .createdDateTime(archive.getCreatedDateTime())
                 .modifiedDateTime(archive.getModifiedDateTime())
                 .comments(commentDTOs)
-                .build();
-    }
-
-    public ArchivePageResponseDTO createArchivePageResponse(Page<Archive> archivePage, String username) {
-        List<ArchiveOutputDTO> archives = archivePage.isEmpty() ? 
-                new ArrayList<>() : 
-                archivePage.getContent().stream()
-                    .map(archive -> convertToDTO(archive, username, archive.getView()))
-                    .toList();
-        
-        return ArchivePageResponseDTO.builder()
-                .archives(archives)
-                .totalPages(archivePage.getTotalPages())
                 .build();
     }
 

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/ArchiveSummaryDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/ArchiveSummaryDTO.java
@@ -1,0 +1,18 @@
+package sequence.sequence_member.mypage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ArchiveSummaryDTO {
+    private Long id;
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String thumbnail;
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/InvitedProjectWithCommentDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/InvitedProjectWithCommentDTO.java
@@ -1,0 +1,16 @@
+package sequence.sequence_member.mypage.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class InvitedProjectWithCommentDTO {
+    private final Long projectInvitedMemberId; // 초대된 초대장 id
+    private final String writer; // 작성자_닉네임
+    private final String title; // 제목
+    private final LocalDate inviteDate; // 초대일
+    private int commentCount;   // 댓글수
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/PortfolioDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/PortfolioDTO.java
@@ -3,8 +3,7 @@ package sequence.sequence_member.mypage.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import sequence.sequence_member.archive.dto.ArchivePageResponseDTO;
-import sequence.sequence_member.member.dto.InviteProjectOutputDTO;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -17,6 +16,6 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class PortfolioDTO {
-    private ArchivePageResponseDTO archivePage;
-    private List<InviteProjectOutputDTO> invitedProjects;
+    private Page<ArchiveSummaryDTO> archivePage;
+    private List<InvitedProjectWithCommentDTO> invitedProjects;
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageService.java
@@ -12,11 +12,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import sequence.sequence_member.archive.entity.Archive;
 import sequence.sequence_member.archive.repository.ArchiveRepository;
+import sequence.sequence_member.global.exception.UserNotFindException;
 import sequence.sequence_member.member.dto.CustomUserDetails;
 import sequence.sequence_member.member.entity.MemberEntity;
 import sequence.sequence_member.member.repository.MemberRepository;
 import sequence.sequence_member.mypage.dto.*;
+import sequence.sequence_member.project.entity.ProjectInvitedMember;
+import sequence.sequence_member.project.repository.CommentRepository;
+import sequence.sequence_member.project.repository.ProjectInvitedMemberRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -27,6 +32,8 @@ public class MyPageService {
     private final MemberRepository memberRepository;
     private final ArchiveRepository archiveRepository;
     private final MyPageMapper myPageMapper;
+    private final ProjectInvitedMemberRepository projectInvitedMemberRepository;
+    private final CommentRepository commentRepository;
 
     /**
      * 주어진 사용자명(username)에 해당하는 마이페이지 정보를 조회합니다.
@@ -44,8 +51,12 @@ public class MyPageService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
 
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdDateTime").descending());
-        Page<Archive> archivePage = archiveRepository.findByArchiveMembers_Member_Id(member.getId(), pageable);
-        return myPageMapper.toMyPageResponseDto(member, archivePage, customUserDetails);
+        Page<Archive> archivePage = archiveRepository.findByWriter(member, pageable);
+
+        List<InvitedProjectWithCommentDTO> invitedProjects = getInvitedProjects(customUserDetails);
+
+        return myPageMapper.toMyPageResponseDto(member, archivePage, invitedProjects);
+
     }
 
     /**
@@ -72,13 +83,11 @@ public class MyPageService {
     }
 
     /**
-     * 주어진 nickname에 해당하는 마이페이지 정보를 조회합니다.
+     * 주어진 사용자 정보를 기반으로 해당 사용자가 초대받은 프로젝트 목록과
+     * 각 프로젝트의 댓글 수를 포함한 정보를 조회합니다.
      *
-     * @param nickname 조회할 회원의 nickname
-     * @param page archive 페이지네이션 파라미터
-     * @param size archive 페이지네이션 파라미터
-     *
-     * @return 사용자의 마이페이지 정보를 담은 DTO
+     * @param customUserDetails 현재 인증된 사용자의 정보
+     * @return 초대받은 프로젝트 정보와 각 프로젝트의 댓글 수를 담은 DTO 리스트
      * @throws EntityNotFoundException 사용자를 찾을 수 없는 경우 발생
      */
     public MyPageResponseDTO getUserProfile(String nickname, int page, int size, CustomUserDetails customUserDetails) {
@@ -86,8 +95,40 @@ public class MyPageService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
 
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdDateTime").descending());
-        Page<Archive> archivePage = archiveRepository.findByArchiveMembers_Member_Id(member.getId(), pageable);
+        Page<Archive> archivePage = archiveRepository.findByWriter(member, pageable);
 
-        return myPageMapper.toMyPageResponseDto(member, archivePage, customUserDetails);
+        List<InvitedProjectWithCommentDTO> invitedProjects = getInvitedProjects(customUserDetails);
+
+        return myPageMapper.toMyPageResponseDto(member, archivePage, invitedProjects);
+    }
+
+    /**
+     * 유저가 초대받은 프로젝트 목록을 조회하는 메인 로직 함수
+     * @param customUserDetails
+     * @return
+     */
+    @Transactional
+    public List<InvitedProjectWithCommentDTO> getInvitedProjects(CustomUserDetails customUserDetails) {
+        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername())
+                .orElseThrow(() -> new UserNotFindException("해당 유저가 존재하지 않습니다."));
+
+        List<ProjectInvitedMember> inviteList = projectInvitedMemberRepository.findByMemberId(member.getId());
+
+        List<InvitedProjectWithCommentDTO> result = new ArrayList<>();
+
+        for (ProjectInvitedMember detail : inviteList) {
+            Long projectId = detail.getProject().getId();
+            int commentCount = commentRepository.countByProjectId(projectId);   // 댓글수 가져오기
+
+            result.add(InvitedProjectWithCommentDTO.builder()
+                    .projectInvitedMemberId(detail.getProject().getId())
+                    .title(detail.getProject().getTitle())
+                    .writer(detail.getProject().getWriter().getNickname())
+                    .inviteDate(detail.getCreatedDateTime().toLocalDate())
+                    .commentCount(commentCount)
+                    .build());
+        }
+
+        return result;
     }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/project/repository/CommentRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/repository/CommentRepository.java
@@ -1,9 +1,12 @@
 package sequence.sequence_member.project.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import sequence.sequence_member.project.entity.Comment;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment,Long> {
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.project.id = :projectId")
+    int countByProjectId(Long projectId);
 }


### PR DESCRIPTION
[목적]
- PortfolioDTO 내 archives 데이터 단순화
- 초대된 프로젝트의 댓글 수 데이터 추가

[변경 내용]
- ArchiveSummaryDTO 추가
- InvitedProjectWithCommentDTO 추가

[결과]
- MyPage 관련 DTO 구조 및 반환 데이터 개선
- 가독성과 유지보수성 향상