### PR TITLE
[feat]: 로그인 정보 수정 기능 추가

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/controller/MyPageController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/controller/MyPageController.java
@@ -1,13 +1,17 @@
 package sequence.sequence_member.mypage.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +21,7 @@ import sequence.sequence_member.global.response.Code;
 import sequence.sequence_member.member.dto.CustomUserDetails;
 import sequence.sequence_member.mypage.dto.MyPageRequestDTO;
 import sequence.sequence_member.mypage.dto.MyPageResponseDTO;
+import sequence.sequence_member.mypage.dto.UpdateLoginInfoRequestDTO;
 import sequence.sequence_member.mypage.service.MyPageService;
 
 import java.util.List;
@@ -82,5 +87,24 @@ public class MyPageController {
             );
             return ResponseEntity.status(Code.CAN_NOT_FIND_RESOURCE.getStatus()).body(errorResponse);
         }
+    }
+
+    @PostMapping("/api/mypage/update")
+    public ResponseEntity<ApiResponseData<String>> updateUserInfo(
+            @Valid @RequestBody UpdateLoginInfoRequestDTO updateLoginInfoRequestDTO, Errors errors
+    ) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        myPageService.updateUserInfo(updateLoginInfoRequestDTO, username, errors);
+
+        if (!updateLoginInfoRequestDTO.isPasswordMatching()) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(ApiResponseData.failure(
+                            Code.CAN_NOT_FIND_RESOURCE.getCode(),
+                            "비밀번호와 비밀번호 확인이 일치하지 않습니다.")
+                    );
+        }
+
+        return ResponseEntity.ok(ApiResponseData.success("로그인 정보 수정이 완료되었습니다."));
     }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/UpdateLoginInfoRequestDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/UpdateLoginInfoRequestDTO.java
@@ -1,0 +1,48 @@
+package sequence.sequence_member.mypage.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sequence.sequence_member.member.entity.MemberEntity;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateLoginInfoRequestDTO {
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    private String name;
+
+    @NotNull(message = "생년월일은 필수 입력 값입니다.")
+    private LocalDate birth;
+
+    @NotNull(message = "성별은 필수 입력 값입니다.")
+    private MemberEntity.Gender gender;
+
+    @NotBlank(message = "주소지는 필수 입력 값입니다.")
+    private String address;
+
+    @NotBlank(message = "휴대폰 번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$", message = "휴대폰 번호 형식이 올바르지 않습니다.")
+    private String phone;
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank
+    private String newPassword;
+
+    @NotBlank
+    private String confirmPassword;
+
+    @AssertTrue(message = "비밀번호와 비밀번호 확인이 일치하지 않습니다.")
+    public boolean isPasswordMatching() {
+        return newPassword != null && newPassword.equals(confirmPassword);
+    }
+}

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageService.java
@@ -7,32 +7,41 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import org.springframework.validation.Errors;
 import org.springframework.web.multipart.MultipartFile;
 import sequence.sequence_member.archive.entity.Archive;
 import sequence.sequence_member.archive.repository.ArchiveRepository;
+import sequence.sequence_member.global.response.ApiResponseData;
+import sequence.sequence_member.global.response.Code;
 import sequence.sequence_member.member.dto.CustomUserDetails;
 import sequence.sequence_member.member.dto.InviteProjectOutputDTO;
 import sequence.sequence_member.member.entity.MemberEntity;
 import sequence.sequence_member.member.repository.MemberRepository;
 import sequence.sequence_member.member.service.InviteAccessService;
+import sequence.sequence_member.member.service.MemberService;
 import sequence.sequence_member.mypage.dto.*;
 import sequence.sequence_member.project.repository.CommentRepository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
     private final MyPageUpdateService myPageUpdateService;
+    private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final ArchiveRepository archiveRepository;
     private final MyPageMapper myPageMapper;
     private final CommentRepository commentRepository;
     private final InviteAccessService inviteAccessService;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     /**
      * 주어진 사용자명(username)에 해당하는 마이페이지 정보를 조회합니다.
@@ -126,5 +135,42 @@ public class MyPageService {
         }
 
         return result;
+    }
+
+    /**
+     * 로그인 정보 수정하는 메인 로직 함수
+     *
+     * @param updateLoginInfoRequestDTO 변경할 사용자 로그인 정보
+     *
+     * @throws EntityNotFoundException 사용자를 찾을 수 없는 경우 발생
+     */
+    @Transactional
+    public ResponseEntity<ApiResponseData<Object>> updateUserInfo(UpdateLoginInfoRequestDTO updateLoginInfoRequestDTO, String username, Errors errors) {
+        // 로그인 정보 수정
+        MemberEntity member = memberRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
+
+        //회원가입 유효성 검사 실패 시
+        if(errors.hasErrors()){
+            Map<String, String> validatorResult = memberService.validateHandling(errors);
+            return ResponseEntity.badRequest().body(ApiResponseData.failure(Code.INVALID_INPUT.getCode(), validatorResult.values().toString()));
+        }
+
+        member.setName(updateLoginInfoRequestDTO.getName());
+        member.setBirth(updateLoginInfoRequestDTO.getBirth());
+        member.setGender(updateLoginInfoRequestDTO.getGender());
+        member.setAddress(updateLoginInfoRequestDTO.getAddress());
+        member.setPhone(updateLoginInfoRequestDTO.getPhone());
+        member.setEmail(updateLoginInfoRequestDTO.getEmail());
+
+        // 비밀번호 수정 (입력된 경우만)
+        if (updateLoginInfoRequestDTO.getNewPassword() == null
+                && updateLoginInfoRequestDTO.getNewPassword().isBlank()) {
+            throw new IllegalArgumentException("수정할 비밀번호가 입력되지 않았습니다.");
+        }
+
+        member.setPassword(bCryptPasswordEncoder.encode(updateLoginInfoRequestDTO.getNewPassword()));
+
+        return null;
     }
 }


### PR DESCRIPTION
[목적]
- 기본 로그인 정보 수정 기능 구현
- 비밀번호 변경 기능 추가

[변경 내용]
- /api/mypage/update API 추가
- 비밀번호는 유효성 검사 후 인코딩하여 저장

[결과]
- 로그인 정보 및 비밀번호 수정 기능 구현 완료