### PR TITLE
fix : 탈퇴한 멤버는 로그인 불가능

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveBookmarkService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveBookmarkService.java
@@ -35,7 +35,7 @@ public class ArchiveBookmarkService {
         Archive archive = archiveRepository.findById(archiveId)
             .orElseThrow(() -> new CanNotFindResourceException("아카이브를 찾을 수 없습니다."));
         
-        MemberEntity userId = memberRepository.findByUsername(username)
+        MemberEntity userId = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new UserNotFindException("회원을 찾을 수 없습니다."));
 
         Optional<ArchiveBookmark> bookmark = bookmarkRepository.findByArchiveAndUserId(archive, userId);
@@ -56,7 +56,7 @@ public class ArchiveBookmarkService {
 
     // 사용자의 북마크 목록 조회
     public List<Long> getUserBookmarks(String username) {
-        MemberEntity userId = memberRepository.findByUsername(username)
+        MemberEntity userId = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new UserNotFindException("회원을 찾을 수 없습니다."));
         
         return bookmarkRepository.findAllByUserId(userId).stream()
@@ -69,7 +69,7 @@ public class ArchiveBookmarkService {
         Archive archive = archiveRepository.findById(archiveId)
             .orElseThrow(() -> new CanNotFindResourceException("아카이브를 찾을 수 없습니다."));
         
-        MemberEntity userId = memberRepository.findByUsername(username)
+        MemberEntity userId = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new UserNotFindException("회원을 찾을 수 없습니다."));
         
         return bookmarkRepository.existsByArchiveAndUserId(archive, userId);

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveCommentService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveCommentService.java
@@ -37,7 +37,7 @@ public class ArchiveCommentService {
     @Transactional
     public Long createComment(Long archiveId, String username, CommentCreateRequestDTO dto) {
         // username으로 사용자 조회하여 nickname 가져오기
-        MemberEntity member = memberRepository.findByUsername(username)
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
         
         // 아카이브 조회
@@ -79,7 +79,7 @@ public class ArchiveCommentService {
     @Transactional
     public boolean updateComment(Long archiveId, Long commentId, String username, CommentUpdateRequestDTO dto) {
         // username으로 사용자 정보 조회
-        MemberEntity member = memberRepository.findByUsername(username)
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
         
         Optional<Archive> archiveOpt = archiveRepository.findById(archiveId);
@@ -112,7 +112,7 @@ public class ArchiveCommentService {
     @Transactional
     public boolean deleteComment(Long archiveId, Long commentId, String username) {
         // username으로 사용자 조회하여 nickname 가져오기
-        MemberEntity member = memberRepository.findByUsername(username)
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
         
         Optional<Archive> archiveOpt = archiveRepository.findById(archiveId);

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/ArchiveService.java
@@ -116,7 +116,7 @@ public class ArchiveService {
     @Transactional
     public boolean deleteArchive(Long archiveId, String username) {
         // 사용자 검증
-        Optional<MemberEntity> memberOpt = memberRepository.findByUsername(username);
+        Optional<MemberEntity> memberOpt = memberRepository.findByUsernameAndIsDeletedFalse(username);
         if (memberOpt.isEmpty()) {
             return false;
         }
@@ -159,7 +159,7 @@ public class ArchiveService {
     @Transactional(readOnly = true)
     public List<UserArchiveDTO> getUserArchiveListAtAlarm(CustomUserDetails customUserDetails){
         // 사용자 검증
-        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername())
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."));
 
         List<Archive> latestArchives = archiveRepository.findTop10ByArchiveMembers_Member_IdOrderByCreatedDateTimeDesc((member.getId()));
@@ -173,7 +173,7 @@ public class ArchiveService {
     @Transactional(readOnly = true)
     public List<UserArchiveDTO> getUserArchiveList(CustomUserDetails customUserDetails) {
         // 사용자 검증
-        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername())
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "사용자를 찾을 수 없습니다."));
 
         // 평가완료 상태인 아카이브만 조회
@@ -190,7 +190,7 @@ public class ArchiveService {
 
     public ArchiveListDTO getAllArchives(int page, SortType sortType, String username) {
         if (username != null) {
-            memberRepository.findByUsername(username)
+            memberRepository.findByUsernameAndIsDeletedFalse(username)
                 .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
         }
 
@@ -225,7 +225,7 @@ public class ArchiveService {
             String username) {
         
         if (username != null) {
-            memberRepository.findByUsername(username)
+            memberRepository.findByUsernameAndIsDeletedFalse(username)
                 .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
         }
 
@@ -291,7 +291,7 @@ public class ArchiveService {
         boolean isBookmarked = false;
         if (username != null && !username.isEmpty()) {
             // username으로 MemberEntity 조회
-            Optional<MemberEntity> memberOpt = memberRepository.findByUsername(username);
+            Optional<MemberEntity> memberOpt = memberRepository.findByUsernameAndIsDeletedFalse(username);
             if (memberOpt.isPresent()) {
                 MemberEntity userId = memberOpt.get();
                 isBookmarked = bookmarkRepository.existsByArchiveAndUserId(archive, userId);
@@ -365,7 +365,7 @@ public class ArchiveService {
             MultipartFile thumbnailFile,
             List<MultipartFile> imageFiles) throws Exception {
         
-        MemberEntity member = memberRepository.findByUsername(username)
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
 
         Archive archive = createArchiveEntity(dto, member);

--- a/sequence_member/src/main/java/sequence/sequence_member/archive/service/TeamEvaluationService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/archive/service/TeamEvaluationService.java
@@ -48,7 +48,7 @@ public class TeamEvaluationService {
             .orElseThrow(() -> new ArchiveNotFoundException("아카이브 정보를 찾을 수 없습니다."));
             
         // username으로 멤버 찾기
-        MemberEntity member = memberRepository.findByUsername(username)
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
             
         // 평가자의 ArchiveMember 정보 조회
@@ -119,7 +119,7 @@ public class TeamEvaluationService {
     // 아카이브의 모든 평가 완료 여부 확인 메소드 수정
     public boolean isAllEvaluationCompleted(Long archiveId, String username) {
         // username으로 멤버 찾기
-        MemberEntity member = memberRepository.findByUsername(username)
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
             
         // 평가자의 ArchiveMember 정보 조회
@@ -135,7 +135,7 @@ public class TeamEvaluationService {
 
     public TeamEvaluationStatusResponseDTO getEvaluationStatus(Long archiveId, String username) {
         // username으로 멤버 찾기
-        MemberEntity member = memberRepository.findByUsername(username)
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
             
         // 평가자의 ArchiveMember 정보 조회
@@ -218,7 +218,7 @@ public class TeamEvaluationService {
             .orElseThrow(() -> new ArchiveNotFoundException("아카이브 정보를 찾을 수 없습니다."));
         
         // username으로 멤버 찾기
-        MemberEntity member = memberRepository.findByUsername(username)
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(username)
             .orElseThrow(() -> new BAD_REQUEST_EXCEPTION("사용자를 찾을 수 없습니다."));
             
         // 평가자의 ArchiveMember 정보 조회

--- a/sequence_member/src/main/java/sequence/sequence_member/global/utils/MockDataInitializer.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/utils/MockDataInitializer.java
@@ -28,7 +28,7 @@ public class MockDataInitializer implements ApplicationRunner {
     public void run(ApplicationArguments args) {
 
         // 이미 목데이터 생성되었는지를 판단함.
-        if (memberRepository.findByUsername("1_0_username").isPresent()) {
+        if (memberRepository.findByUsernameAndIsDeletedFalse("1_0_username").isPresent()) {
             return;
         }
 

--- a/sequence_member/src/main/java/sequence/sequence_member/member/jwt/LoginFilter.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/jwt/LoginFilter.java
@@ -87,7 +87,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException{
         //유저 이름 찾기
         String username = authentication.getName();
-        MemberEntity memberEntity = memberRepository.findByUsername(username).orElseThrow(()->new BaseException("해당 유저가 존재하지 않습니다."));
+        MemberEntity memberEntity = memberRepository.findByUsernameAndIsDeletedFalse(username).orElseThrow(()->new BaseException("해당 유저가 존재하지 않습니다."));
         
         String access = jwtUtil.createJwt("access",username,  600000L*60*24*100); // 24시간 *100 = 100일. 테스트를 위해 기한 늘림
         String refresh = jwtUtil.createJwt("refresh", username, 86400000L*100); // 24시간 *100 = 100일

--- a/sequence_member/src/main/java/sequence/sequence_member/member/repository/MemberRepository.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/repository/MemberRepository.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<MemberEntity,Long> {
-    Optional<MemberEntity> findByUsername(String username);
+    Optional<MemberEntity> findByUsernameAndIsDeletedFalse(String username);
     Optional<MemberEntity> findByNickname(String nickname);
     Optional<MemberEntity> findByEmail(String email);
     boolean existsByNickname(String nickname);

--- a/sequence_member/src/main/java/sequence/sequence_member/member/service/CustomUserDetailsService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/service/CustomUserDetailsService.java
@@ -21,7 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Optional<MemberEntity> memberData =  memberRepository.findByUsername(username);
+        Optional<MemberEntity> memberData =  memberRepository.findByUsernameAndIsDeletedFalse(username);
 
         if(memberData.isPresent()){
             return new CustomUserDetails(memberData.get());

--- a/sequence_member/src/main/java/sequence/sequence_member/member/service/DeleteService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/service/DeleteService.java
@@ -36,7 +36,7 @@ public class DeleteService {
 
         //username 가져오기
         String username = jwtUtil.getUsername(refresh);
-        MemberEntity deleteMember = memberRepository.findByUsername(username)
+        MemberEntity deleteMember = memberRepository.findByUsernameAndIsDeletedFalse(username)
                 .orElseThrow(() -> new CanNotFindResourceException("사용자를 찾을 수 없습니다."));
 
 //        //회원 정보 삭제

--- a/sequence_member/src/main/java/sequence/sequence_member/member/service/InviteAccessService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/service/InviteAccessService.java
@@ -33,7 +33,7 @@ public class InviteAccessService {
      */
     @Transactional(readOnly = true)
     public List<InviteProjectOutputDTO> getInvitedProjects(CustomUserDetails customUserDetails){
-        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername()).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
         List<ProjectInvitedMember> inviteList = projectInvitedMemberRepository.findByMemberId(member.getId());
         List<InviteProjectOutputDTO> inviteProjectOutputDTOList = new ArrayList<>();
         for(ProjectInvitedMember detail : inviteList ){
@@ -54,7 +54,7 @@ public class InviteAccessService {
      */
     @Transactional
     public void acceptInvite(CustomUserDetails customUserDetails, Long projectInvitedMemberId){
-        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElseThrow(() -> new UserNotFindException("해당 유저가 존재하지 않습니다."));
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername()).orElseThrow(() -> new UserNotFindException("해당 유저가 존재하지 않습니다."));
         ProjectInvitedMember projectInvitedMember = projectInvitedMemberRepository.findByIdAndMemberId(projectInvitedMemberId,member.getId()).orElseThrow(() -> new BAD_REQUEST_EXCEPTION("해당 프로젝트 초대가 유효하지 않습니다."));
 
         projectMemberRepository.save(ProjectMember.builder()
@@ -67,7 +67,7 @@ public class InviteAccessService {
 
     @Transactional
     public void rejectInvite(CustomUserDetails customUserDetails, Long projectInvitedMemberId){
-        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElseThrow(() -> new UserNotFindException("해당 유저가 존재하지 않습니다."));
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername()).orElseThrow(() -> new UserNotFindException("해당 유저가 존재하지 않습니다."));
         ProjectInvitedMember projectInvitedMember = projectInvitedMemberRepository.findByIdAndMemberId(projectInvitedMemberId,member.getId()).orElseThrow(() -> new BAD_REQUEST_EXCEPTION("해당 프로젝트 초대가 유효하지 않습니다."));
         projectInvitedMemberRepository.delete(projectInvitedMember);
     }
@@ -78,7 +78,7 @@ public class InviteAccessService {
      * @return
      */
     public List<AcceptProjectOutputDTO> getAcceptedProjects(CustomUserDetails customUserDetails){
-        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername()).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
         List<ProjectMember> projectMembers = projectMemberRepository.findByMemberId(member.getId());
         List<AcceptProjectOutputDTO> acceptProjectOutputDTOList = new ArrayList<>();
         for(ProjectMember detail : projectMembers ){

--- a/sequence_member/src/main/java/sequence/sequence_member/member/service/MemberSearchService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/service/MemberSearchService.java
@@ -18,7 +18,7 @@ public class MemberSearchService {
 
     @Transactional(readOnly = true)
     public List<String> searchMemberNicknames(CustomUserDetails customUserDetails, String nickname){
-        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername())
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername())
                 .orElseThrow(() -> new UserNotFindException("요청하는 유저가 존재하지 않습니다."));
         Pageable pageable = PageRequest.of(0, 20);  // 첫 페이지, 최대 20개
         List<String> nicknames = memberRepository.searchMemberNicknames(nickname, pageable);

--- a/sequence_member/src/main/java/sequence/sequence_member/member/service/MemberService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/member/service/MemberService.java
@@ -65,7 +65,7 @@ public class MemberService {
         //먼저 member 정보를 저장하고 나중에 외래키 값을 저장하기 위해서 멤버 정보를 먼저 저장
         memberRepository.save(memberEntity);
 
-        MemberEntity memberEntityCopy =  memberRepository.findByUsername(memberDTO.getUsername()).get();
+        MemberEntity memberEntityCopy =  memberRepository.findByUsernameAndIsDeletedFalse(memberDTO.getUsername()).get();
 
         List<AwardEntity> awardEntities = AwardEntity.toAwardEntity(memberDTO, memberEntityCopy);
         List<ExperienceEntity> experienceEntities = ExperienceEntity.toExperienceEntity(memberDTO, memberEntityCopy);
@@ -111,7 +111,7 @@ public class MemberService {
         if (username == null || username.trim().isEmpty()) {
             throw new IllegalArgumentException("아이디를 입력해주세요");
         }
-        return memberRepository.findByUsername(username).isPresent();
+        return memberRepository.findByUsernameAndIsDeletedFalse(username).isPresent();
     }
 
     //닉네임 중복 체크
@@ -135,6 +135,6 @@ public class MemberService {
         if(username == null || username.trim().isEmpty()){
             throw new IllegalArgumentException("아이디를 입력해주세요.");
         }
-        return memberRepository.findByUsername(username).get();
+        return memberRepository.findByUsernameAndIsDeletedFalse(username).get();
     }
 }

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageService.java
@@ -46,7 +46,7 @@ public class MyPageService {
      * @throws EntityNotFoundException 사용자를 찾을 수 없는 경우 발생
      */
     public MyPageResponseDTO getMyProfile(String username, int page, int size, CustomUserDetails customUserDetails) {
-        MemberEntity member = memberRepository.findByUsername(username)
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(username)
                 .orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
 
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdDateTime").descending());
@@ -71,7 +71,7 @@ public class MyPageService {
             MyPageRequestDTO myPageDTO, String username,
             MultipartFile authImgFile, List<MultipartFile> portfolios
     ) {
-        MemberEntity member = memberRepository.findByUsername(username)
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(username)
                 .orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
       
         if (!Objects.equals(myPageDTO.getUsername(), username)) {

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/CommentService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/CommentService.java
@@ -33,7 +33,7 @@ public class CommentService {
      */
     @Transactional
     public void writeComment(CustomUserDetails customUserDetails, Long projectId, CommentInputDTO commentInputDTO){
-        MemberEntity writer = memberRepository.findByUsername(customUserDetails.getUsername()).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
+        MemberEntity writer = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername()).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
         Project project = projectRepository.findById(projectId).orElseThrow(()-> new CanNotFindResourceException("해당 프로젝트가 존재하지 않습니다."));
         commentRepository.save(createComment(commentInputDTO, writer, project));
     }
@@ -49,7 +49,7 @@ public class CommentService {
     public void updateComment(CustomUserDetails customUserDetails, Long projectId, Long commentId, CommentUpdateDTO commentUpdateDTO){
 
         //각 리소스가 존재하는지 확인
-        MemberEntity writer = memberRepository.findByUsername(customUserDetails.getUsername()).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
+        MemberEntity writer = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername()).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
         Project project = projectRepository.findById(projectId).orElseThrow(()-> new CanNotFindResourceException("해당 프로젝트가 존재하지 않습니다."));
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CanNotFindResourceException("해당 댓글이 존재하지 않습니다."));
@@ -78,7 +78,7 @@ public class CommentService {
     @Transactional
     public void deleteComment(CustomUserDetails customUserDetails, Long projectId, Long commentId){
         //각 리소스가 존재하는지 확인
-        MemberEntity writer = memberRepository.findByUsername(customUserDetails.getUsername()).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
+        MemberEntity writer = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername()).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
         Project project = projectRepository.findById(projectId).orElseThrow(()-> new CanNotFindResourceException("해당 프로젝트가 존재하지 않습니다."));
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CanNotFindResourceException("해당 댓글이 존재하지 않습니다."));

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectBookmarkService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectBookmarkService.java
@@ -26,7 +26,7 @@ public class ProjectBookmarkService {
     public String addBookmark(CustomUserDetails customUserDetails, Long projectId) {
         StringBuilder errMessgage=new StringBuilder(); //만약 null이 아닐경우 오류가 발생한것
         // 유저와 프로젝트 존재 여부 확인
-        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElse(null);
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername()).orElse(null);
         Project project = projectRepository.findById(projectId).orElse(null);
 
         if(member == null){
@@ -60,7 +60,7 @@ public class ProjectBookmarkService {
         //todo- 코드 반복됨. 리팩토링 고민
         StringBuilder errMessgage=new StringBuilder(); //만약 null이 아닐경우 오류가 발생한것
         // 유저와 프로젝트 존재 여부 확인
-        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElse(null);
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername()).orElse(null);
         Project project = projectRepository.findById(projectId).orElse(null);
 
         if(member == null){

--- a/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/project/service/ProjectService.java
@@ -45,7 +45,7 @@ public class ProjectService {
 
     @Transactional
     public void createProject(ProjectInputDTO projectInputDTO, String username){
-        MemberEntity writer = memberRepository.findByUsername(username).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
+        MemberEntity writer = memberRepository.findByUsernameAndIsDeletedFalse(username).orElseThrow(()-> new UserNotFindException("해당 유저가 존재하지 않습니다."));
         Project project = projectRepository.save(Project.fromProjectInput(projectInputDTO,writer));
 
         saveProjectInvitedMember(projectInputDTO, writer, project);
@@ -159,7 +159,7 @@ public class ProjectService {
     public ProjectOutputDTO updateProject(Long projectId, CustomUserDetails customUserDetails, ProjectUpdateDTO projectUpdateDTO,HttpServletRequest request) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new CanNotFindResourceException("해당 프로젝트가 존재하지 않습니다."));
-        MemberEntity writer = memberRepository.findByUsername(customUserDetails.getUsername())
+        MemberEntity writer = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername())
                 .orElseThrow(() -> new UserNotFindException("요청하는 유저가 존재하지 않습니다."));
         if (!project.getWriter().equals(writer)) {
             throw new AuthException("작성자만 수정할 수 있습니다.");
@@ -199,7 +199,7 @@ public class ProjectService {
     public void deleteProject(Long projectId, CustomUserDetails customUserDetails){
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new CanNotFindResourceException("해당 프로젝트가 존재하지 않습니다."));
-        MemberEntity writer = memberRepository.findByUsername(customUserDetails.getUsername())
+        MemberEntity writer = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername())
                 .orElseThrow(() -> new UserNotFindException("해당 유저가 존재하지 않습니다."));
         if (!project.getWriter().equals(writer)) {
             throw new AuthException("작성자만 삭제할 수 있습니다.");
@@ -292,7 +292,7 @@ public class ProjectService {
         if (customUserDetails == null) {
             return false;
         }
-        MemberEntity member = memberRepository.findByUsername(customUserDetails.getUsername()).orElse(null);
+        MemberEntity member = memberRepository.findByUsernameAndIsDeletedFalse(customUserDetails.getUsername()).orElse(null);
         if (member == null) {
             return false;
         }

--- a/sequence_member/src/main/java/sequence/sequence_member/report/service/ReportService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/report/service/ReportService.java
@@ -59,7 +59,7 @@ public class ReportService {
 
         // Refresh Token과 username이 일치하는지 확인
         String tokenUsername = jwtUtil.getUsername(refresh);
-        Optional<MemberEntity> member = memberRepository.findByUsername(tokenUsername);
+        Optional<MemberEntity> member = memberRepository.findByUsernameAndIsDeletedFalse(tokenUsername);
         String tokenNickname = member.get().getNickname();
 
         boolean exist = memberRepository.existsByNickname(reportRequestDTO.getNickname());


### PR DESCRIPTION
- isdeleted가 true인 멤버는 조회가 안되도록 jpa query method를 수정 (탈퇴멤버는 조회안됨)
- 시큐리티 로그인 필터에서, 탈퇴한 멤버가 로그인 한다면 customuserdetails가 생성되지 않아서, 로그인 실패가 되도록 처리